### PR TITLE
The frontend method 'render_content_shortcode' has an 'eval' call tha…

### DIFF
--- a/php/front-end/class-frontend.php
+++ b/php/front-end/class-frontend.php
@@ -225,7 +225,7 @@ class Frontend {
 			add_shortcode( self::CONTENT_SHORTCODE, [ $this, 'render_content_shortcode' ] );
 		}
 
-		return $content;
+		return trim($content);
 	}
 
 	/**


### PR DESCRIPTION
The frontend method `render_content_shortcode`has an `eval` call that adds two lines of whitespace that are not needed past `eval` processing so requesting the 'content' string be trimmed on return.

This caused issues with a website I am working on that  needs 100% empty values returned if no values exist in a code snippet. The source of the issue is these empty lines on line 206 which is `eval( "?>\n\n" . $snippet->code . "\n\n<?php" );` in the `render_content_shortcode` method contained in the `Frontend` class in the file `php/front-end/class-frontend.php`.

The solution I found is to just wrap the returned `$content` with `trim` like this: `return trim($content);`.
