### PR TITLE
fix: restore the missing toolbar border

### DIFF
--- a/src/css/common/_subnav.scss
+++ b/src/css/common/_subnav.scss
@@ -9,7 +9,6 @@
 	// Bleed across the full admin content width, flush against the plugin toolbar.
 	box-sizing: border-box;
 	min-block-size: 53px;
-	margin-block-start: -1px;
 	margin-inline-start: -22px;
 	inline-size: calc(100% + 42px);
 	overflow: hidden;

--- a/src/css/common/_toolbar.scss
+++ b/src/css/common/_toolbar.scss
@@ -19,6 +19,7 @@ $wpcontent-inline-start-indent: 20px;
 	inset-block-start: 0;
 	display: flex;
 	flex-direction: column;
+	z-index: 1;
 
 	ul, li {
 		margin: 0;

--- a/src/css/common/_toolbar.scss
+++ b/src/css/common/_toolbar.scss
@@ -19,7 +19,6 @@ $wpcontent-inline-start-indent: 20px;
 	inset-block-start: 0;
 	display: flex;
 	flex-direction: column;
-	z-index: 1;
 
 	ul, li {
 		margin: 0;


### PR DESCRIPTION
Fix the missing border in the toolbar.


Before:

<img width="1512" height="282" alt="before" src="https://github.com/user-attachments/assets/06e2796c-f56c-4140-a1d0-29e949983391" />

After:

<img width="1512" height="279" alt="after" src="https://github.com/user-attachments/assets/8e6b23e8-4a8e-4787-8238-6f3330eb1875" />
