### PR TITLE
fix: remove redundant space above import container

### DIFF
--- a/src/css/common/_wp-admin.scss
+++ b/src/css/common/_wp-admin.scss
@@ -6,8 +6,9 @@ body.wp-admin {
 	background: #f0f0f1;
 }
 
-// Remove the WordPress core 10px top margin on the manage snippets container
+// Remove the WordPress core 10px top margin on the import and manage snippets containers
 // so the subnav band sits flush against the toolbar.
+#import-container.wrap,
 #manage-snippets-container.wrap {
 	margin-block-start: 0;
 }


### PR DESCRIPTION
Before:

<img width="1512" height="315" alt="Screenshot 2026-08-21 at 11 19 56" src="https://github.com/user-attachments/assets/7a8706ef-312d-44ad-8e73-7a31f219d1cf" />

After:

<img width="1512" height="308" alt="Screenshot 2026-08-21 at 11 21 25" src="https://github.com/user-attachments/assets/a646f1d7-8575-48ca-b696-a087ab3b1bd6" />
