### PR TITLE
fix: load admin bar script dependencies on the front end

### DIFF
--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -14,7 +14,7 @@ declare global {
 			readonly editor?: WordPressEditor
 			readonly codeEditor?: WordPressCodeEditor
 		}
-		readonly pagenow: string
+		readonly pagenow?: string
 		readonly ajaxurl: string
 		readonly tinymce?: tinymce.EditorManager
 		readonly wpActiveEditor?: string

--- a/src/js/utils/screen.ts
+++ b/src/js/utils/screen.ts
@@ -1,5 +1,7 @@
+// `pagenow` is only defined inside wp-admin. This module is also reached from
+// the admin bar bundle, which loads on the front end, so read it defensively.
 export const isNetworkAdmin = (): boolean =>
-	window.pagenow.endsWith('-network')
+	true === window.pagenow?.endsWith('-network')
 
 export const isMacOS = (): boolean =>
 	null !== /mac/i.exec(window.navigator.userAgent)

--- a/src/php/Integration/Admin_Bar.php
+++ b/src/php/Integration/Admin_Bar.php
@@ -91,7 +91,7 @@ class Admin_Bar {
 		wp_enqueue_script(
 			self::SCRIPT_HANDLE,
 			plugins_url( 'dist/admin-bar.js', PLUGIN_FILE ),
-			[],
+			[ 'wp-i18n', 'wp-url' ],
 			PLUGIN_VERSION,
 			[ 'in_footer' => true ]
 		);

--- a/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
+++ b/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
@@ -84,6 +84,20 @@ test.describe('Admin Bar Snippets QuickNav', () => {
 		await expect(activeControls).toBeVisible()
 	})
 
+	test('QuickNav loads on the front end without JavaScript errors', async ({ page }) => {
+		const errors: string[] = []
+		page.on('pageerror', error => errors.push(error.message))
+
+		await page.goto('/')
+
+		// The admin bar bundle is enqueued on the front end as well as in wp-admin,
+		// but `wp.i18n`, `wp.url` and `pagenow` are only present in wp-admin unless
+		// the script declares them. Loading it here proves those are satisfied.
+		await expect(page.locator('#wpadminbar')).toBeVisible()
+		await expect(page.locator('#wp-admin-bar-code-snippets')).toHaveCount(1)
+		expect(errors).toEqual([])
+	})
+
 	test('Manage submenu contains status quick links', async ({ page }) => {
 		test.setTimeout(QUICKNAV_TEST_TIMEOUT_MS)
 


### PR DESCRIPTION
## The bug

Every logged-in visitor on the **front end** of a 3.10.0 site gets an uncaught exception on page load:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'i18n')
    at admin-bar.js?ver=3.10.0:2:6557
```

The QuickNav admin bar menu still renders (the nodes are server-side), but its JavaScript never initialises, so pagination and the search field don't work. Reported against `3.10.0-beta.2` and confirmed present in the released `v3.10.0` tag.

## Cause

`Admin_Bar::enqueue_assets()` is hooked to both `admin_enqueue_scripts` and `wp_enqueue_scripts`, but registers the script with an empty dependency array.

The bundle needs two WordPress globals it never asks for:

```
entries/admin-bar.ts
└── utils/snippets/snippets.ts
    ├── import { __, sprintf } from '@wordpress/i18n'   → window.wp.i18n
    └── import { buildUrl } from '../urls'
        └── import { addQueryArgs } from '@wordpress/url' → window.wp.url
```

`config/webpack/webpack-js.ts` externalises every `@wordpress/*` package to `['wp', …]`, so the built file reads `window.wp.i18n` at module scope. In wp-admin those handles are already enqueued by other code, so it works by luck. On the front end nothing loads them, `window.wp` is undefined, and the bundle throws before it does anything.

The same chain also reaches `window.pagenow` via `utils/screen.ts`. That one is an admin-only localised global, not a registered script handle, so it can't be fixed by declaring a dependency — it needs a guard.

## The fix

- Declare `[ 'wp-i18n', 'wp-url' ]` on the admin bar script.
- `isNetworkAdmin()` reads `window.pagenow` defensively, and `Window.pagenow` is typed optional so the guard is enforced rather than incidental. It is the only usage.

## Verification

Reproduced and confirmed fixed on the front end as a logged-in user:

| | before | after |
|---|---|---|
| `wp-i18n` script tag | absent | present |
| `typeof window.wp.i18n` | `undefined` | `object` |
| JS errors | `TypeError: … reading 'i18n'` | none |

- Added a front-end case to the QuickNav spec. The existing tests only visit `/wp-admin/…`, which is exactly why this escaped. It fails without the enqueue change and passes with it.
- `chromium-db-snippets`: 90 passed. PHPUnit: 157 tests, 0 failures. `lint:js` and `lint:styles` clean.

## Notes

- No changelog entry added — I didn't want to guess the next version number ahead of `(Tag): Prepare`. Happy to add one if you'd rather it be explicit.
- This is on `pro-beta` too, so it wants syncing down after merge.
