### PR TITLE
fix: persist the row truncation Screen Option

### DIFF
--- a/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
@@ -13,12 +13,6 @@ class Manage_Menu_Screen_Options {
 	 * Register hooks this class.
 	 */
 	public function __construct() {
-		// Deliberately `wp_loaded`, not `admin_init`. Core handles the Screen
-		// Options form in `set_screen_options()` at wp-admin/admin.php:116, which
-		// ends in `wp_safe_redirect()` and `exit` — before `admin_init` fires at
-		// line 180. A handler on `admin_init` never runs for the request that
-		// carries the form, so the preference is silently discarded. `wp_loaded`
-		// fires from wp-load.php before any of that.
 		add_action( 'wp_loaded', [ $this, 'save_truncation_preference' ] );
 		add_filter( 'set-screen-option', [ $this, 'save_per_page_option' ], 10, 3 );
 	}

--- a/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
@@ -13,7 +13,13 @@ class Manage_Menu_Screen_Options {
 	 * Register hooks this class.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', [ $this, 'save_truncation_preference' ] );
+		// Deliberately `wp_loaded`, not `admin_init`. Core handles the Screen
+		// Options form in `set_screen_options()` at wp-admin/admin.php:116, which
+		// ends in `wp_safe_redirect()` and `exit` — before `admin_init` fires at
+		// line 180. A handler on `admin_init` never runs for the request that
+		// carries the form, so the preference is silently discarded. `wp_loaded`
+		// fires from wp-load.php before any of that.
+		add_action( 'wp_loaded', [ $this, 'save_truncation_preference' ] );
 		add_filter( 'set-screen-option', [ $this, 'save_per_page_option' ], 10, 3 );
 	}
 

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -506,4 +506,26 @@ test.describe('Manage table Screen Options', () => {
 		await truncationToggle.check()
 		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeVisible()
 	})
+
+	test('Truncation preference survives Apply and a page reload', async ({ page }) => {
+		await openScreenOptions(page)
+		await page.locator('#snippets-table-truncate-row-values').uncheck()
+
+		// Core handles this form before `admin_init`, so a preference saved on that
+		// hook is silently dropped. Applying and reloading is the only way to tell
+		// a real save from the client-side class toggle above.
+		await page.locator('#screen-options-apply').click()
+		await page.waitForLoadState('networkidle')
+
+		await helper.navigateToSnippetsAdmin()
+		await openScreenOptions(page)
+
+		await expect(page.locator('#snippets-table-truncate-row-values')).not.toBeChecked()
+		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeHidden()
+
+		// Restore the default so later tests and the dev site are unaffected.
+		await page.locator('#snippets-table-truncate-row-values').check()
+		await page.locator('#screen-options-apply').click()
+		await page.waitForLoadState('networkidle')
+	})
 })


### PR DESCRIPTION
## The bug

Toggling **Truncate long snippet names and descriptions** in Screen Options looks like it works — the table updates instantly and the checkbox stays where you put it — but the preference is never saved. Every reload falls back to the default, so rows always end up truncated.

## Cause

`save_truncation_preference()` was hooked to `admin_init`.

Core handles the Screen Options form in `set_screen_options()`, called at **wp-admin/admin.php:116**, which ends with:

```php
wp_safe_redirect( $url );
exit;
```

`do_action( 'admin_init' )` is at **line 180**. The handler never ran for the request carrying the form data, and no hook priority could change that — the process has already exited.

The per-page option is unaffected because it saves via the `set-screen-option` filter, which fires *inside* `set_screen_options()` before the redirect. That asymmetry is what makes the bug look strange: same form, one option saves and the other doesn't.

Demonstrated in a single submit — unchecking truncate and setting per-page to 37, then applying and reloading:

| | after Apply + reload |
|---|---|
| per-page | **37 — saved** |
| truncate | **reverted to checked** |

## The fix

Move the handler to `wp_loaded`, which fires from wp-load.php before admin.php reaches line 116. All of its existing nonce, capability and page guards read `$_REQUEST`, so nothing depended on the later hook. Left a comment at the hook so it doesn't get "tidied" back to `admin_init`.

## Why this wasn't caught

The instant visual feedback comes from a React listener on `#adv-settings` in `SnippetsListTable.tsx` — pure client-side DOM state. The existing test, *"Truncation toggle applies and removes the truncation class in real time"*, asserts only that class, so it passed the whole time.

Added *"Truncation preference survives Apply and a page reload"*, which applies the form and reloads. It **fails on `admin_init` and passes on `wp_loaded`**, and restores the default afterwards so it doesn't leak state into other tests.

## Verification

`chromium-db-snippets`: 90 passed. PHPUnit: 157 tests, 0 failures. `lint:js` and `lint:styles` clean.

## Notes

- No changelog entry, same as #461 — didn't want to guess a version ahead of `(Tag): Prepare`.
- Present on `pro-beta` too; wants syncing down after merge.



Fixes #478
