### PR TITLE
fix: send snippet modification dates with a UTC offset

### DIFF
--- a/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
@@ -111,6 +111,9 @@ class Manage_Menu_Assets {
 				function ( Snippet $snippet ) {
 					$fields = $snippet->get_fields();
 					$fields['code'] = '';
+					// Match the REST response: a UTC value with no offset is read
+					// as local time by the browser.
+					$fields['modified'] = $snippet->modified_iso;
 					return $fields;
 				},
 				get_snippets()

--- a/src/php/Model/Snippet.php
+++ b/src/php/Model/Snippet.php
@@ -464,6 +464,24 @@ class Snippet extends Model {
 	}
 
 	/**
+	 * Retrieve the modification date as an ISO 8601 string, including the UTC
+	 * offset.
+	 *
+	 * `$modified` is stored as 'Y-m-d H:i:s' in UTC, which carries no offset, so
+	 * anything parsing it — a browser, in particular — is free to read it as
+	 * local time and land the snippet hours away from when it was really saved.
+	 * This is the form to hand to clients.
+	 *
+	 * @return string|null ISO 8601 date, or null if no modification date is set.
+	 * @noinspection PhpUnused
+	 */
+	protected function get_modified_iso(): ?string {
+		$timestamp = $this->get_modified_timestamp();
+
+		return $timestamp ? gmdate( 'c', $timestamp ) : null;
+	}
+
+	/**
 	 * Retrieve the modification time in the local timezone.
 	 *
 	 * @return DateTime

--- a/src/php/REST_API/Snippets/Snippets_REST_Controller.php
+++ b/src/php/REST_API/Snippets/Snippets_REST_Controller.php
@@ -826,6 +826,10 @@ final class Snippets_REST_Controller extends REST_Collection_Controller {
 			$response[ $property ] = $item->$property;
 		}
 
+		// The schema declares this as a date-time, so send one: the stored value
+		// is UTC without an offset, which clients read as local time.
+		$response['modified'] = $item->modified_iso;
+
 		return rest_ensure_response( $response );
 	}
 

--- a/tests/unit/Model/Snippet_Test.php
+++ b/tests/unit/Model/Snippet_Test.php
@@ -30,4 +30,40 @@ class Snippet_Test extends UnitTestCase {
 
 		$this->assertSame( $description, $snippet->desc );
 	}
+
+	/**
+	 * The modification date is exposed to clients with an explicit UTC offset.
+	 *
+	 * Stored as 'Y-m-d H:i:s' in UTC, the raw value carries no offset, so a
+	 * browser reads it as local time and shows a snippet saved moments ago as
+	 * hours into the future on any site behind UTC.
+	 *
+	 * @return void
+	 */
+	public function test_modified_is_exposed_as_iso_8601_utc(): void {
+		$snippet = new Snippet(
+            [
+				'name' => 'Timezone',
+				'modified' => '2026-08-27 07:35:20',
+			]
+        );
+
+		$this->assertSame( '2026-08-27T07:35:20+00:00', $snippet->modified_iso );
+		$this->assertNotSame(
+			$snippet->modified,
+			$snippet->modified_iso,
+			'the stored value has no offset, so it must not be handed to clients as-is'
+		);
+	}
+
+	/**
+	 * A snippet with no modification date exposes null rather than an epoch date.
+	 *
+	 * @return void
+	 */
+	public function test_modified_iso_is_null_when_unset(): void {
+		$snippet = new Snippet( [ 'name' => 'Never modified' ] );
+
+		$this->assertNull( $snippet->modified_iso );
+	}
 }


### PR DESCRIPTION
## The bug

Reported from support against 3.10.0: the **Modified** column shows recently saved snippets in the future — "6 hours from now" on a site at UTC−6, and by whatever the offset is elsewhere. Reproduced exactly.

## Cause

`Snippet::update_modified()` writes `gmdate( 'Y-m-d H:i:s' )`. The value is UTC, but that format carries **no offset**.

Both paths that hand snippets to the browser passed it through verbatim:

- `Snippets_REST_Controller::prepare_item_for_response()` — whose schema already declares `'format' => 'date-time'` and describes the field as "in ISO format", which it wasn't
- the inline `snippetsList` payload in `Manage_Menu_Assets`

The table then calls `humanTimeDiff( snippet.modified )`. An offset-less string is parsed as **local** time, so on any site behind UTC every recent snippet lands in the future by exactly the site's offset.

## The fix

`Snippet::get_modified_iso()` returns the same instant as ISO 8601 with an explicit offset, reusing the existing UTC-aware `get_modified_timestamp()`. Both output paths now send that.

Side benefit: `<time datetime="…">` is now a valid datetime attribute, which it previously wasn't.

**The stored format is unchanged** — nothing about how dates are written, sorted or compared moves. This only affects what goes over the wire.

## Verification

Reproduced the reporter's environment: WordPress 7.0.4, PHP 8.2.33, Code Snippets 3.10.0 (the released zip), 190 snippets, site at UTC−6.

| | before | after |
|---|---|---|
| Modified cell | `6 hours from now` | `21 minutes ago` |
| `datetime` attribute | `2026-08-27 07:35:20` | `2026-08-27T07:35:20+00:00` |

Plus two unit tests covering the ISO output and the null case for a snippet that was never modified. They fail without the change.

PHPUnit: 159 tests, 0 failures. `lint:js` and `lint:styles` clean.

## Note

No changelog entry, consistent with #461 and #462 — didn't want to pick a version ahead of `(Tag): Prepare`.



Fixes #479
