### PR TITLE
fix: apply the Snippets List Order setting again

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/SnippetsListTable.tsx
@@ -12,7 +12,7 @@ import { getTableColumns } from './TableColumns'
 import { useFilteredSnippets } from './WithFilteredSnippetsContext'
 import { INDEX_STATUS, useSnippetsFilters } from './WithSnippetsTableFilters'
 import { BULK_ACTIONS, TRASHED_BULK_ACTIONS, useApplyBulkAction } from './useApplyBulkAction'
-import type { ListTableAction } from '../../common/ListTable'
+import type { ListTableAction, ListTableSortDirection } from '../../common/ListTable'
 import type { SnippetsTableAction } from './useApplyBulkAction'
 import type { Snippet } from '../../../types/Snippet'
 import type { SnippetView } from '../../../types/SnippetView'
@@ -141,6 +141,7 @@ const SnippetsView: React.FC<SnippetsViewProps> = ({
 		: <ListTable
 			items={snippets}
 			getKey={snippet => snippet.id}
+			initialSort={getInitialSort()}
 			className={classnames({ 'truncate-row-values': truncateRowValues })}
 			columns={columns}
 			actions={actions}
@@ -154,6 +155,23 @@ const SnippetsView: React.FC<SnippetsViewProps> = ({
 			beforeTable={<SearchResultsIndicator />}
 		/>
 }
+
+/**
+ * The "Snippets List Order" setting names a default ordering for the table,
+ * which sorting is now expressed through columns. Map one to the other so the
+ * setting still decides how the list opens; clicking a heading overrides it for
+ * the rest of the visit, as it does for any other starting order.
+ */
+const LIST_ORDER_SORTS: Record<string, { columnId: string, direction: ListTableSortDirection }> = {
+	'priority-asc': { columnId: 'priority', direction: 'asc' },
+	'name-asc': { columnId: 'name', direction: 'asc' },
+	'name-desc': { columnId: 'name', direction: 'desc' },
+	'modified-desc': { columnId: 'date', direction: 'desc' },
+	'modified-asc': { columnId: 'date', direction: 'asc' }
+}
+
+const getInitialSort = () =>
+	LIST_ORDER_SORTS[window.CODE_SNIPPETS_MANAGE?.listOrder ?? ''] ?? undefined
 
 export interface SnippetsListTableProps {
 	snippetView: SnippetView

--- a/src/js/components/common/ListTable/ListTable.tsx
+++ b/src/js/components/common/ListTable/ListTable.tsx
@@ -129,6 +129,9 @@ export interface ListTableProps<T, K extends Key, A extends string> extends List
 	items: T[]
 	beforeTable?: ReactNode
 	selectAllControl?: boolean
+
+	/** Column and direction to sort by before the reader touches a heading. */
+	initialSort?: { columnId: string, direction: ListTableSortDirection }
 }
 
 export const ListTable = <T, K extends Key, A extends string = never>({
@@ -136,13 +139,20 @@ export const ListTable = <T, K extends Key, A extends string = never>({
 	getKey,
 	totalPages,
 	pageSearchParam = 'paged',
+	initialSort,
 	...tableProps
 }: ListTableProps<T, K, A>) => {
-	const [sortColumn, setSortColumn] = useState<ListTableColumn<T>>()
+	const [sortColumn, setSortColumn] = useState<ListTableColumn<T> | undefined>(
+		() => initialSort
+			? tableProps.columns.find(column => column.id === initialSort.columnId && column.sortedValue)
+			: undefined
+	)
 	const [currentPage, setCurrentPage] = useState(
 		() => pageSearchParam && Number(fetchQueryParam(pageSearchParam)) || 1
 	)
-	const [sortDirection, setSortDirection] = useState<ListTableSortDirection>('asc')
+	const [sortDirection, setSortDirection] = useState<ListTableSortDirection>(
+		() => initialSort?.direction ?? 'asc'
+	)
 
 	const visibleItems: T[] = useMemo(
 		() => pageItems(sortTableItems(items, sortColumn, sortDirection), { currentPage, totalPages }),

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -69,6 +69,7 @@ declare global {
 			snippetsList?: Snippet[]
 			hasNetworkCap: boolean
 			hiddenColumns: string[]
+			listOrder?: string
 			truncateRowValues: number | string
 			snippetsPerPage: number
 			typeCounts?: Record<string, number>

--- a/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
@@ -103,6 +103,7 @@ class Manage_Menu_Assets {
 			'supportsZipDownloads' => class_exists( 'ZipArchive' ),
 			'editorTheme'          => get_setting( 'editor', 'theme' ),
 			'typeCounts'           => $this->get_snippet_type_counts(),
+			'listOrder'            => get_setting( 'general', 'list_order' ),
 		];
 
 		if ( $this->screen_options->is_manage_table_view() ) {

--- a/tests/e2e/code-snippets-list.spec.ts
+++ b/tests/e2e/code-snippets-list.spec.ts
@@ -507,3 +507,42 @@ test.describe('Manage table Screen Options', () => {
 		await expect(page.locator('.wp-list-table.truncate-row-values')).toBeVisible()
 	})
 })
+
+test.describe('Snippets list order setting', () => {
+	const PREFIX = 'E2E Order Test'
+	const names = ['E2E Order Test Alpha', 'E2E Order Test Zulu']
+
+	test.beforeAll(async () => {
+		await SnippetsTestHelper.cleanupSnippetsByPrefix(PREFIX)
+		for (const name of names) {
+			await SnippetsTestHelper.createSnippetViaCli({ name, active: false, type: 'php' })
+		}
+	})
+
+	test.afterAll(async () => {
+		await SnippetsTestHelper.cleanupSnippetsByPrefix(PREFIX)
+		await SnippetsTestHelper.setListOrder('priority-asc')
+	})
+
+	const firstMatchingName = async (page: Page): Promise<string> => {
+		const rows = page.locator(`${SELECTORS.SNIPPET_ROW}:has(a${SELECTORS.SNIPPET_NAME_LINK})`)
+		await rows.first().waitFor()
+		const all = await rows.locator(`a${SELECTORS.SNIPPET_NAME_LINK}`).allInnerTexts()
+		return all.find(name => name.startsWith(PREFIX)) ?? ''
+	}
+
+	// The setting describes itself as the default order for this screen, so it
+	// decides how the table opens. Sorting moved to the column headings during
+	// the admin rewrite and the setting was left reading nothing at all.
+	test('Snippets List Order decides the order the table opens in', async ({ page }) => {
+		const helper = new SnippetsTestHelper(page)
+
+		await SnippetsTestHelper.setListOrder('name-asc')
+		await helper.navigateToSnippetsAdmin()
+		expect(await firstMatchingName(page)).toBe('E2E Order Test Alpha')
+
+		await SnippetsTestHelper.setListOrder('name-desc')
+		await helper.navigateToSnippetsAdmin()
+		expect(await firstMatchingName(page)).toBe('E2E Order Test Zulu')
+	})
+})

--- a/tests/e2e/helpers/SnippetsTestHelper.ts
+++ b/tests/e2e/helpers/SnippetsTestHelper.ts
@@ -55,6 +55,10 @@ export class SnippetsTestHelper {
 		await wpCli(['eval', php])
 	}
 
+	static async setListOrder(order: string): Promise<void> {
+		await wpCli(['eval', `\\Code_Snippets\\Settings\\update_setting('general', 'list_order', '${order}');`])
+	}
+
 	static async setSnippetsPerPage(perPage: number): Promise<void> {
 		const php = `
 			$user = get_user_by('login', 'admin');

--- a/tests/unit/Admin/Menus/Manage/Manage_Menu_Assets_Test.php
+++ b/tests/unit/Admin/Menus/Manage/Manage_Menu_Assets_Test.php
@@ -52,6 +52,7 @@ class Manage_Menu_Assets_Test extends AdminUnitTestCase {
 				'supportsZipDownloads',
 				'editorTheme',
 				'typeCounts',
+				'listOrder',
 				'snippetsList',
 			],
 			array_keys( $localized )


### PR DESCRIPTION
## The bug

Reported from support: **Settings → Snippets List Order** has no effect. Whichever of its five options you pick, the All Snippets table opens in the same order.

Reproduced on two clean installs — WP 7.0.4 / PHP 8.2.33 and WP 7.1 / PHP 8.3.33. `Name (Z-A)` should invert the list; nothing moved on either.

## Cause

The setting is still defined and still rendered, but **nothing reads it**. Its only two references in 3.10.0:

```
Settings_Fields.php:91    'list_order' => 'priority-asc',   ← default value
Settings_Fields.php:191   'list_order' => [ … ],            ← the field in Settings
```

Until 3.10 the list table applied it directly:

```php
// 3.9.2 — class-list-table.php:1311
$order = Settings\get_setting( 'general', 'list_order' );
```

Sorting moved to the column headings during the admin rewrite. The consumer went with the old table; the setting stayed in the UI, reading nothing.

## Approach

The headings are the mechanism now, so this doesn't restore a parallel ordering system. It maps the setting onto the table's **opening sort** — which is what the setting describes itself as: *"Default way to order snippets on the All Snippets admin menu."*

- `list_order` is localized alongside the other manage data
- mapped to a column id and direction (`priority`/`name`/`date`, asc/desc)
- passed to `ListTable` as a new optional `initialSort`

Clicking a heading overrides it for the rest of the visit, exactly as it overrides any other starting order. The `initialSort` prop is optional, so no other `ListTable` consumer changes behaviour.

**On removing it instead:** that was the alternative, and it's defensible given headings supersede it. I didn't, because it's a visible feature removal for anyone who has it configured, and the value is carried in saved settings either way — honouring it costs less than taking it away. Easy to flip if you'd rather retire the setting.

## Verification

Against a reproduction of the reported environment (WP 7.0.4, PHP 8.2.33, 3.10.0, 190 snippets):

| `list_order` | before | after |
|---|---|---|
| `priority-asc` | Repro 001, 002, 003, 004 | Repro 002, 003, 004, 005 |
| `name-desc` | Repro 001, 002, 003, 004 | **Repro 190, 189, 188, 187** |

An e2e test covers it and **fails without the change**. Full suite: 90 Playwright, 157 PHPUnit, 0 failures; `lint:js` and `lint:styles` clean.

`Manage_Menu_Assets_Test` pins the localized key list, so it gains `listOrder`.

## Note

No changelog entry, consistent with #461, #462 and #463.



Fixes #474
