### PR TITLE
fix: register the Edit Snippet menu item only while editing

### DIFF
--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -4,7 +4,6 @@ namespace Code_Snippets\Admin\Menus;
 
 use Code_Snippets\Admin\Contextual_Help;
 use Code_Snippets\Model\Snippet;
-use WP_Screen;
 use function Code_Snippets\code_snippets;
 use function Code_Snippets\get_all_snippet_tags;
 use function Code_Snippets\get_snippet;
@@ -49,8 +48,6 @@ class Edit_Menu extends Admin_Menu {
 			__( 'Edit Snippet', 'code-snippets' )
 		);
 
-		add_action( 'current_screen', array( $this, 'maybe_hide_menu_item' ) );
-
 		$this->remove_debug_bar_codemirror();
 	}
 
@@ -60,13 +57,94 @@ class Edit_Menu extends Admin_Menu {
 	 * @return void
 	 */
 	public function register() {
-		parent::register();
+		// The page itself is always registered outside the menu, so nothing that
+		// reads the menu during `admin_menu` — menu editors and role managers
+		// among them — ever sees it. Registering it in the menu and removing it
+		// afterwards is why a page that never renders in the menu could still end
+		// up in someone's saved menu.
+		$this->register_without_menu_item();
+
+		$snippet_id = $this->get_requested_snippet_id();
+
+		if ( $snippet_id ) {
+			$this->add_current_snippet_menu_item( $snippet_id );
+		}
 
 		// Create New Snippet menu.
 		$this->add_menu(
 			code_snippets()->get_menu_slug( 'add' ),
 			_x( 'Add New', 'menu label', 'code-snippets' ),
 			__( 'Create New Snippet', 'code-snippets' )
+		);
+	}
+
+	/**
+	 * The snippet this request is editing, if any.
+	 *
+	 * Read from the request rather than the current screen, because this runs
+	 * during `admin_menu`, before the screen is known.
+	 *
+	 * @return int Snippet ID, or 0 when not editing a specific snippet.
+	 */
+	private function get_requested_snippet_id(): int {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only routing parameter.
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+
+		if ( $page !== $this->slug ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only routing parameter.
+		return isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+	}
+
+	/**
+	 * Register the edit page without placing it in the admin menu.
+	 *
+	 * @return void
+	 */
+	private function register_without_menu_item(): void {
+		$hook = add_submenu_page(
+			'',
+			$this->title,
+			$this->label,
+			code_snippets()->get_cap(),
+			$this->slug,
+			array( $this, 'render' )
+		);
+
+		if ( $hook ) {
+			add_action( 'load-' . $hook, array( $this, 'load' ) );
+		}
+	}
+
+	/**
+	 * Mark the snippet being edited in the menu.
+	 *
+	 * Added as a plain link rather than a second registration of the page: a
+	 * submenu slug doubles as the identifier WordPress checks permissions
+	 * against, so carrying the ID in the slug would make `page=edit-snippet`
+	 * match nothing and the screen would refuse to load.
+	 *
+	 * @param int $snippet_id Snippet being edited.
+	 *
+	 * @return void
+	 */
+	private function add_current_snippet_menu_item( int $snippet_id ): void {
+		add_submenu_page(
+			$this->base_slug,
+			$this->title,
+			$this->label,
+			code_snippets()->get_cap(),
+			add_query_arg(
+				[
+					'page' => $this->slug,
+					'id'   => $snippet_id,
+				],
+				'admin.php'
+			),
+			'',
+			1
 		);
 	}
 
@@ -81,26 +159,6 @@ class Edit_Menu extends Admin_Menu {
 			$this->get_hookname(),
 			get_plugin_page_hookname( code_snippets()->get_menu_slug( 'add' ), $this->base_slug ),
 		];
-	}
-
-	/**
-	 * Hide the static Edit Snippet menu item unless a specific snippet is being edited.
-	 *
-	 * @param WP_Screen $screen Current admin screen.
-	 *
-	 * @return void
-	 */
-	public function maybe_hide_menu_item( WP_Screen $screen ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only admin menu context.
-		$current_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
-		$edit_hook  = get_plugin_page_hookname( $this->slug, $this->base_slug );
-		$edit_hook .= $screen->in_admin( 'network' ) ? '-network' : '';
-
-		if ( ( $screen->id === $edit_hook || $screen->base === $edit_hook ) && 0 < $current_id ) {
-			return;
-		}
-
-		remove_submenu_page( $this->base_slug, $this->slug );
 	}
 
 	/**

--- a/tests/unit/Admin/Menus/Edit_Menu_Test.php
+++ b/tests/unit/Admin/Menus/Edit_Menu_Test.php
@@ -26,64 +26,80 @@ class Edit_Menu_Test extends AdminUnitTestCase {
 	}
 
 	/**
-	 * The edit submenu item remains registered so the page stays directly accessible.
+	 * Reset request state between tests.
 	 *
 	 * @return void
 	 */
-	public function test_register_keeps_edit_submenu_item(): void {
-		$menu = new Edit_Menu();
-		$menu->register();
-
-		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
-		$submenu_slugs = array_column( $submenu, 2 );
-
-		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
-		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	public function tear_down() {
+		unset( $_GET['page'], $_GET['id'] );
+		parent::tear_down();
 	}
 
 	/**
-	 * Hide the edit submenu item outside the snippet edit screen.
+	 * Slugs currently listed under the Snippets menu.
 	 *
-	 * @return void
+	 * @return string[]
 	 */
-	public function test_maybe_hide_menu_item_removes_edit_submenu_outside_edit_screen(): void {
-		$menu = new Edit_Menu();
-		$menu->register();
-
-		$menu->maybe_hide_menu_item( get_current_screen() );
-
-		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
-		$submenu_slugs = array_column( $submenu, 2 );
-
-		$this->assertNotContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
-		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $submenu_slugs );
+	private function get_snippets_submenu_slugs(): array {
+		return array_column( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [], 2 );
 	}
 
 	/**
-	 * Keep the edit submenu item visible while editing a specific snippet.
+	 * The edit page stays registered so it remains reachable by URL.
 	 *
 	 * @return void
 	 */
-	public function test_maybe_hide_menu_item_keeps_edit_submenu_on_edit_screen(): void {
+	public function test_register_keeps_edit_page_reachable(): void {
 		$menu = new Edit_Menu();
 		$menu->register();
 
-		$screen = get_current_screen();
-		$hook = get_plugin_page_hookname(
-			code_snippets()->get_menu_slug( 'edit' ),
-			code_snippets()->get_menu_slug()
-		);
+		$hidden_slugs = array_column( $GLOBALS['submenu'][''] ?? [], 2 );
 
-		$screen->id = $hook;
-		$screen->base = $hook;
+		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $hidden_slugs );
+		$this->assertContains( code_snippets()->get_menu_slug( 'add' ), $this->get_snippets_submenu_slugs() );
+	}
+
+	/**
+	 * The edit item is absent from the menu when no snippet is being edited.
+	 *
+	 * Anything reading the menu during `admin_menu` — menu editors and role
+	 * managers among them — should never see it, so it must not be registered
+	 * there and removed afterwards.
+	 *
+	 * @return void
+	 */
+	public function test_edit_item_absent_from_menu_when_not_editing(): void {
+		$menu = new Edit_Menu();
+		$menu->register();
+
+		foreach ( $this->get_snippets_submenu_slugs() as $slug ) {
+			$this->assertStringNotContainsString(
+				code_snippets()->get_menu_slug( 'edit' ),
+				$slug,
+				'the edit page must not appear in the Snippets menu outside the edit screen'
+			);
+		}
+	}
+
+	/**
+	 * While editing, the item appears and carries the snippet being edited.
+	 *
+	 * @return void
+	 */
+	public function test_edit_item_links_to_the_snippet_being_edited(): void {
+		$_GET['page'] = code_snippets()->get_menu_slug( 'edit' );
 		$_GET['id'] = '11';
 
-		$menu->maybe_hide_menu_item( $screen );
+		$menu = new Edit_Menu();
+		$menu->register();
 
-		$submenu = $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] ?? [];
-		$submenu_slugs = array_column( $submenu, 2 );
+		$matching = array_filter(
+			$this->get_snippets_submenu_slugs(),
+			fn( $slug ) => false !== strpos( $slug, code_snippets()->get_menu_slug( 'edit' ) )
+		);
 
-		$this->assertContains( code_snippets()->get_menu_slug( 'edit' ), $submenu_slugs );
+		$this->assertCount( 1, $matching, 'the edit item should appear while editing a snippet' );
+		$this->assertStringContainsString( 'id=11', reset( $matching ) );
 	}
 
 	/**
@@ -96,16 +112,5 @@ class Edit_Menu_Test extends AdminUnitTestCase {
 
 		$this->assertFalse( has_action( 'admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
 		$this->assertFalse( has_action( 'network_admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
-	}
-
-	/**
-	 * The edit menu hides its submenu item using the current_screen hook.
-	 *
-	 * @return void
-	 */
-	public function test_edit_menu_uses_current_screen_to_hide_menu_item(): void {
-		$menu = new Edit_Menu();
-
-		$this->assertNotFalse( has_action( 'current_screen', [ $menu, 'maybe_hide_menu_item' ] ) );
 	}
 }


### PR DESCRIPTION
Draft — the approach is worth a look before this goes further, particularly the choice to keep the ID on a link rather than in the registered slug.

## Reported

<https://wordpress.org/support/topic/edit-snippet/> — two problems in one thread, with one cause.

**1. The item is registered globally.** The reporter uses Admin Menu Editor Pro to keep other admins out of the Snippets area, and "Edit Snippet" keeps reappearing in their menu after updates.

**2. Selecting it starts a new snippet.** As acknowledged in the thread: the item is meant to mark the page you're on, but following it lands on Add New.

## Cause

`Edit_Menu` registered the item unconditionally on `admin_menu` and removed it afterwards on `current_screen`, which fires later. Nothing ever rendered it — but it genuinely sat in `$submenu` in between.

A probe reading the menu at the end of `admin_menu`, which is what a menu editor does, found it on every admin screen:

```
admin_menu(9999) on /wp-admin/index.php               : Edit Snippet => edit-snippet
admin_menu(9999) on /wp-admin/admin.php?page=snippets : Edit Snippet => edit-snippet
```

So the reporter's tooling isn't misbehaving: it captures a genuinely-registered page and persists it. Their access-control complaint is real.

And while editing snippet 5, the item's link was `admin.php?page=edit-snippet` with no ID:

```
editing id=5 — title: "Repro 001 — customise the login page behaviour"
after following "Edit Snippet": url=/wp-admin/admin.php?page=add-snippet
title now: ""    ← a new snippet
```

Unsaved changes go with it.

## Change

The page is registered outside the menu, so it stays reachable by URL but never enters `$submenu` under the Snippets parent. While a snippet is being edited, a plain link to that snippet is added alongside. `maybe_hide_menu_item()` is deleted — registration decides, instead of registering and retracting.

**Why the ID is on a link rather than in the slug** — this is the part worth reviewing. A submenu slug doubles as the identifier WordPress checks permissions against. My first attempt rewrote the registered slug to carry the ID; the edit screen then returned *"Sorry, you are not allowed to access this page"*, because `page=edit-snippet` no longer matched anything registered. That is the "WordPress limitation" from the thread, and adding a separate link is the way around it.

## After

| | before | after |
|---|---|---|
| Menu during `admin_menu`, Dashboard | `parent=snippets` | `parent=(none)` |
| Rendered menu, not editing | absent | absent |
| Rendered menu, editing id=5 | `page=edit-snippet` | `page=edit-snippet&id=5` |
| Following it while editing id=5 | blank new snippet | same snippet |

Verified on WordPress 7.0.4 / PHP 8.2.33 / Code Snippets 3.10.0.

`Edit_Menu_Test` is rewritten for the new design: the page stays reachable, the item is absent when not editing, and carries the ID when it is. All three fail without the change. PHPUnit 156, Playwright 89, `lint:js` and phpcs clean.

## Open questions

- Highlighting: the item is a link rather than a registered page, so WordPress's "current page" styling may not attach to it. It didn't look wrong in testing, but someone who knows the menu internals should confirm.
- Network admin registers through the same path; I haven't exercised multisite.
- No changelog entry, consistent with #461–#465.



Fixes #472
