### PR TITLE
fix: send REST writes as POST with a method override

### DIFF
--- a/src/js/hooks/useRestAPI.tsx
+++ b/src/js/hooks/useRestAPI.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import axios from 'axios'
 import { createContextHook } from '../utils/bootstrap'
-import { REST_API_AXIOS_CONFIG } from '../utils/restAPI'
+import { REST_API_AXIOS_CONFIG, applyMethodOverride } from '../utils/restAPI'
 import type { PropsWithChildren } from 'react'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
@@ -58,7 +58,11 @@ const buildRestAPI = (axiosInstance: AxiosInstance): RestAPI => ({
 const [Context, useRestAPI] = createContextHook<RestAPIContext>('useRestAPI')
 
 export const WithRestAPIContext: React.FC<PropsWithChildren> = ({ children }) => {
-	const axiosInstance = useMemo(() => axios.create(REST_API_AXIOS_CONFIG), [])
+	const axiosInstance = useMemo(() => {
+		const instance = axios.create(REST_API_AXIOS_CONFIG)
+		instance.interceptors.request.use(applyMethodOverride)
+		return instance
+	}, [])
 
 	const api = useMemo(() => buildRestAPI(axiosInstance), [axiosInstance])
 	const value: RestAPIContext = { api, axiosInstance }

--- a/src/js/utils/restAPI.ts
+++ b/src/js/utils/restAPI.ts
@@ -1,5 +1,5 @@
 import { trimTrailingChar } from './text'
-import type { AxiosRequestConfig } from 'axios'
+import type { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 
 const normalizeUrl = (url: string | undefined) =>
 	trimTrailingChar(url ?? '', '/')
@@ -13,6 +13,32 @@ export const REST_BASES = {
 	cloud: {
 		snippets: normalizeUrl(window.CODE_SNIPPETS?.restAPI.cloud.snippets),
 	}
+}
+
+/** Verbs that hosts and firewalls commonly reject outright. */
+const OVERRIDDEN_METHODS = ['delete', 'put', 'patch']
+
+/**
+ * Send write requests as POST, naming the intended verb in a header.
+ *
+ * Plenty of hosts allow only GET and POST, so a DELETE never reaches
+ * WordPress: the request is rejected upstream, and the browser reports a 403 —
+ * or a severed connection — that no amount of correct authentication can fix.
+ * The REST server reads `X-HTTP-Method-Override` on a POST and dispatches the
+ * route exactly as it would have, so this changes nothing WordPress sees while
+ * letting the request through.
+ */
+export const applyMethodOverride = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+	const method = config.method?.toLowerCase()
+
+	if (!method || !OVERRIDDEN_METHODS.includes(method)) {
+		return config
+	}
+
+	config.headers.set('X-HTTP-Method-Override', method.toUpperCase())
+	config.method = 'post'
+
+	return config
 }
 
 export const REST_API_AXIOS_CONFIG: AxiosRequestConfig = {


### PR DESCRIPTION
Draft — targeting `core` for 3.10.1, and the approach is worth a look before it goes further.

## Reported

- <https://wordpress.org/support/topic/critical-bug-version-update-triggers-rest-api-403-forbidden-on-deletion/> — "DELETE 403 (Forbidden)" against `code-snippets/v1/snippets/`, deletion non-functional since updating
- An earlier thread reporting `net::ERR_HTTP2_PROTOCOL_ERROR` with 0 bytes on the same action — almost certainly the same cause, a firewall severing the connection instead of answering 403

## Cause

The admin talks to the REST API over axios and sends real `DELETE` and `PUT` verbs. Many hosts permit only GET and POST, so the request is rejected upstream and never reaches WordPress.

The first reporter suspected missing nonces or auth headers. That part isn't it — `X-WP-Nonce` is sent correctly. Nothing the plugin does with credentials can help, because the request is refused before WordPress runs.

It worked before 3.10 because the old admin went through admin-post and only ever sent POST. The REST rewrite introduced the verb, which is why it appears "since the update".

## Change

Requests using those verbs go out as POST, naming the intended method in `X-HTTP-Method-Override`. `WP_REST_Server::serve_request()` reads that header and dispatches the route exactly as it would have, so WordPress sees an identical request — only the verb on the wire changes. One axios request interceptor; GET and POST are untouched.

## Verified

Against WordPress 7.0.4 / PHP 8.2.33 / Code Snippets 3.10.0, with a stand-in firewall rejecting DELETE/PUT:

| | before | after |
|---|---|---|
| firewall present | `403 DELETE`, snippet remains | `200 POST`, snippet deleted |
| no firewall | `200 DELETE` | `200 POST`, snippet deleted |

## Worth discussing

- **Unconditional, or fall back only on failure?** This overrides always, which is simple and predictable. The alternative — try DELETE, retry as POST on rejection — keeps true verbs where they work, but a genuine permission 403 from WordPress is hard to tell from a firewall 403, so it risks pointless retries. I went with the simpler behaviour; happy to swap.
- Bulk actions delete through the same call, so they're covered, but I haven't specifically exercised a large bulk delete behind the firewall.
- No changelog entry, consistent with the other fixes.



Fixes #473
