### PR TITLE
fix: safe mode fatals with an undefined wp_get_current_user()

### DIFF
--- a/src/php/Integration/Evaluate_Functions.php
+++ b/src/php/Integration/Evaluate_Functions.php
@@ -35,30 +35,52 @@ class Evaluate_Functions {
 		add_action( 'plugins_loaded', [ $this, 'evaluate_early' ], 1 );
 		add_filter( 'code_snippets/execute_snippets', [ $this, 'disable_snippet_execution' ], 5 );
 
-		if ( $this->is_safe_mode_requested() ) {
+		// Only the query var is inspected here. This constructor runs while
+		// plugins are still being included, which is before WordPress loads
+		// pluggable.php, so a capability check at this point would call an
+		// undefined wp_get_current_user() and take the whole request down.
+		// The capability is checked in the callback instead, which never runs
+		// before URLs are being generated.
+		if ( $this->is_safe_mode_query_var_set() ) {
 			add_filter( 'home_url', [ $this, 'add_safe_mode_query_var' ] );
 			add_filter( 'admin_url', [ $this, 'add_safe_mode_query_var' ] );
 		}
 	}
 
 	/**
+	 * Check whether the safe mode query var is present on this request.
+	 *
+	 * Safe to call at any point, as it reads nothing but the request.
+	 *
+	 * @return bool
+	 */
+	public function is_safe_mode_query_var_set(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return ! empty( $_REQUEST['snippets-safe-mode'] );
+	}
+
+	/**
 	 * Check if safe mode has been requested via query var.
+	 *
+	 * Performs a capability check, so must not be called before pluggable
+	 * functions are available.
 	 *
 	 * @return bool
 	 */
 	public function is_safe_mode_requested(): bool {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return ! empty( $_REQUEST['snippets-safe-mode'] ) && code_snippets()->current_user_can();
+		return $this->is_safe_mode_query_var_set() && code_snippets()->current_user_can();
 	}
 
 	/**
 	 * Inject the safe mode query var into URLs
 	 *
-	 * @param string $url Original URL.
+	 * @param mixed $url Original URL, from an unknown earlier callback.
 	 *
 	 * @return string Modified URL.
 	 */
-	public function add_safe_mode_query_var( string $url ): string {
+	public function add_safe_mode_query_var( $url ): string {
+		$url = is_string( $url ) ? $url : '';
+
 		return $this->is_safe_mode_requested() ?
 			add_query_arg( 'snippets-safe-mode', true, $url ) :
 			$url;
@@ -109,12 +131,13 @@ class Evaluate_Functions {
 	/**
 	 * Disable snippet execution if the necessary query var is set.
 	 *
-	 * @param bool $execute_snippets Current filter value.
+	 * @param mixed $execute_snippets Current filter value, from an unknown
+	 *                                earlier callback.
 	 *
 	 * @return bool New filter value.
 	 */
-	public function disable_snippet_execution( bool $execute_snippets ): bool {
-		return $execute_snippets && ! self::is_safe_mode_requested();
+	public function disable_snippet_execution( $execute_snippets ): bool {
+		return (bool) $execute_snippets && ! $this->is_safe_mode_requested();
 	}
 
 	/**

--- a/tests/unit/Integration/Evaluate_Functions_Safe_Mode_Test.php
+++ b/tests/unit/Integration/Evaluate_Functions_Safe_Mode_Test.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Code_Snippets\Integration;
+
+use Code_Snippets\UnitTestCase;
+use function Code_Snippets\code_snippets;
+
+/**
+ * Tests for safe mode request handling.
+ *
+ * @group safe-mode
+ */
+class Evaluate_Functions_Safe_Mode_Test extends UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		unset( $_REQUEST['snippets-safe-mode'] );
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		unset( $_REQUEST['snippets-safe-mode'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * The query var check must not touch capabilities.
+	 *
+	 * The class is constructed while plugins are still being included, which is
+	 * before WordPress loads pluggable.php. A capability check at that point
+	 * calls an undefined wp_get_current_user() and takes the request down, so
+	 * this check has to stay free of anything user-related.
+	 *
+	 * @return void
+	 */
+	public function test_query_var_check_does_not_depend_on_pluggable_functions(): void {
+		$evaluate = new Evaluate_Functions( code_snippets()->db );
+
+		$this->assertFalse( $evaluate->is_safe_mode_query_var_set() );
+
+		$_REQUEST['snippets-safe-mode'] = '1';
+
+		$this->assertTrue( $evaluate->is_safe_mode_query_var_set() );
+	}
+
+	/**
+	 * Constructing the class with the query var set must not be fatal.
+	 *
+	 * @return void
+	 */
+	public function test_constructing_with_the_query_var_set_is_not_fatal(): void {
+		$_REQUEST['snippets-safe-mode'] = '1';
+
+		$evaluate = new Evaluate_Functions( code_snippets()->db );
+
+		$this->assertTrue( $evaluate->is_safe_mode_query_var_set() );
+		$this->assertSame( 10, has_filter( 'admin_url', [ $evaluate, 'add_safe_mode_query_var' ] ) );
+	}
+
+	/**
+	 * The URL callback tolerates a non-string from an earlier callback.
+	 *
+	 * @return void
+	 */
+	public function test_url_callback_tolerates_a_null_from_an_earlier_callback(): void {
+		$evaluate = new Evaluate_Functions( code_snippets()->db );
+
+		$this->assertIsString( $evaluate->add_safe_mode_query_var( null ) );
+	}
+
+	/**
+	 * The execution callback tolerates a non-bool from an earlier callback.
+	 *
+	 * @return void
+	 */
+	public function test_execution_callback_tolerates_a_null_from_an_earlier_callback(): void {
+		$evaluate = new Evaluate_Functions( code_snippets()->db );
+
+		$this->assertFalse( $evaluate->disable_snippet_execution( null ) );
+		$this->assertTrue( $evaluate->disable_snippet_execution( true ) );
+	}
+}


### PR DESCRIPTION
Safe mode is currently unusable. Any request carrying `?snippets-safe-mode=1` dies with a fatal, on 3.10.0 and on released **3.10.1**. Reported by hannab in [this forum thread](https://wordpress.org/support/topic/code-snippets-3-10-0-all-snippets-page-hangs-will-not-load/) — they were told to use safe mode to recover, and hit this instead.

## The bug

```
Fatal error: Uncaught Error: Call to undefined function wp_get_current_user()
in wp-includes/capabilities.php:914
#0 .../php/Plugin.php(282): current_user_can('manage_options')
#1 .../php/Integration/Evaluate_Functions.php(51): Code_Snippets\Plugin->current_user_can()
```

`Evaluate_Functions` is constructed from `Plugin::load_plugin()`, which `Core/load.php:88` calls at include time. The order in `wp-settings.php` is:

| line | what happens |
| ---: | --- |
| 574 | active plugins are included — **our constructor runs here** |
| 604 | `require pluggable.php` — `wp_get_current_user()` defined here |
| 622 | `plugins_loaded` fires |

So the constructor runs 30 lines before the function it depends on exists. The only reason this is not fatal on every request is the `empty()` short-circuit on the query var:

```php
return ! empty( $_REQUEST['snippets-safe-mode'] ) && code_snippets()->current_user_can();
```

Set the query var and the second operand is evaluated, and the request is over.

This matters more than a normal edge case: safe mode is what we tell people to use when a snippet has broken their site, so it fails exactly when it is needed.

## The fix

Split the check in two. The constructor tests only for the query var, which reads nothing but the request and is safe at any point. The capability is checked inside the callback, which cannot run before URLs are being generated, long after pluggable functions are available.

Behaviour is unchanged for a user without the capability — the query var is still never added to URLs.

## Also included

The two filter callbacks in this same file declared non-nullable scalar parameters:

```php
public function add_safe_mode_query_var( string $url ): string
public function disable_snippet_execution( bool $execute_snippets ): bool
```

Neither can trust its input, because an earlier callback in the chain may return anything, and on PHP 8 passing null to a non-nullable scalar is a TypeError regardless of `strict_types`. This is the same defect [Sam reported on the forum](https://wordpress.org/support/topic/plugin-could-not-be-activated-because-it-triggered-a-fatal-error-772/) for `screen_settings`, fixed in #481, and they suggested auditing the rest. `disable_snippet_execution` is hooked to `code_snippets/execute_snippets`, a filter we publish for third parties, and a null there takes down the front end rather than one admin screen.

One remains after this: `Snippet_Files::add_settings_fields( array $fields )` on `code_snippets_settings_fields`. Left out to keep this diff to a single file — happy to follow up.

## Testing

4 new tests in `Evaluate_Functions_Safe_Mode_Test`. All 4 fail on `core` today: two with `Call to undefined method ...::is_safe_mode_query_var_set()` and two with the exact TypeErrors above.

Full suite: 161 tests, 0 failures. `phpcs` clean.

Verified end to end against **released 3.10.1** on WP 7.1 / PHP 8.5:

| | before | after |
| --- | ---: | ---: |
| `/?snippets-safe-mode=1` | fatal, 1.3 KB | clean, 69 KB, closes `</html>` |
| `/` | 200 | 200 |
| `/wp-admin/` | 302 | 302 |

(Worth noting when testing by hand: opcache will happily serve the old bytecode after you swap the file in, which cost me a confusing minute.)
