### PR TITLE
fix: scope cached data to the plugin version so downgrades stop fatalling

### DIFF
--- a/src/php/Core/Uninstaller.php
+++ b/src/php/Core/Uninstaller.php
@@ -67,6 +67,7 @@ class Uninstaller {
 		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}snippets" );
 
 		delete_option( 'code_snippets_version' );
+		delete_option( 'code_snippets_cache_version' );
 		delete_option( 'recently_active_snippets' );
 		delete_option( 'recently_activated_snippets' );
 		delete_option( 'code_snippets_settings' );

--- a/src/php/Core/Upgrader.php
+++ b/src/php/Core/Upgrader.php
@@ -6,6 +6,7 @@ use Code_Snippets\Client\Welcome_Client;
 use Code_Snippets\Model\Snippet;
 use WP_User;
 use function Code_Snippets\clean_snippets_cache;
+use function Code_Snippets\flush_versioned_cache_groups;
 use function Code_Snippets\code_snippets;
 use function Code_Snippets\save_snippet;
 
@@ -13,6 +14,11 @@ use function Code_Snippets\save_snippet;
  * Manages upgrade tasks such as deleting and updating options
  */
 class Upgrader {
+
+	/**
+	 * Option recording the plugin version that last wrote to the cache.
+	 */
+	private const CACHE_VERSION_OPTION = 'code_snippets_cache_version';
 
 	/**
 	 * Instance of database class
@@ -45,6 +51,7 @@ class Upgrader {
 	 * Run the upgrade functions
 	 */
 	public function run() {
+		$this->handle_version_change();
 
 		// Always run multisite upgrades, even if not on the main site, as sub-sites depend on the network snippet table.
 		if ( is_multisite() ) {
@@ -52,6 +59,33 @@ class Upgrader {
 		}
 
 		$this->do_site_upgrades();
+	}
+
+	/**
+	 * Discard cached data belonging to a different version of the plugin.
+	 *
+	 * The do_site_upgrades() method only acts when the version has gone up, so
+	 * it never fires on a rollback. Cached data has to be dealt with in both
+	 * directions, so it is tracked separately here.
+	 *
+	 * A dedicated option is used rather than the one that method maintains,
+	 * because that option is left untouched on a downgrade, which would leave
+	 * this flushing on every request for as long as the older version ran.
+	 *
+	 * @return void
+	 */
+	private function handle_version_change(): void {
+		$previous_version = (string) get_option( self::CACHE_VERSION_OPTION, '' );
+
+		if ( $previous_version === $this->current_version ) {
+			return;
+		}
+
+		// Recorded before flushing so that a cache backend which cannot flush
+		// groups does not leave this repeating on every request.
+		update_option( self::CACHE_VERSION_OPTION, $this->current_version, false );
+
+		flush_versioned_cache_groups( $previous_version );
 	}
 
 	/**

--- a/src/php/Core/load.php
+++ b/src/php/Core/load.php
@@ -32,11 +32,26 @@ const PLUGIN_VERSION = CODE_SNIPPETS_VERSION;
 const PLUGIN_FILE = CODE_SNIPPETS_FILE;
 
 /**
- * Name of the group used for caching data.
+ * Base name of the group used for caching data.
  *
  * @var string
  */
-const CACHE_GROUP = 'code_snippets';
+const CACHE_GROUP_BASE = 'code_snippets';
+
+/**
+ * Name of the group used for caching data.
+ *
+ * Scoped to the plugin version, so data cached by one version is never read by
+ * another. Snippet objects are cached here, and the Snippet class moved
+ * namespace in 3.10. A version that cannot resolve the stored class fatals on
+ * unserialize, which broke the admin for anyone downgrading on a site with a
+ * persistent object cache. Keeping the group distinct per version means the
+ * two never see each other's data, in either direction, without relying on the
+ * other version to clean up after itself.
+ *
+ * @var string
+ */
+const CACHE_GROUP = CACHE_GROUP_BASE . '_' . PLUGIN_VERSION;
 
 /**
  * Namespace used for REST API endpoints.

--- a/src/php/Settings/Settings_Fields.php
+++ b/src/php/Settings/Settings_Fields.php
@@ -139,7 +139,7 @@ class Settings_Fields {
 			'reset_caches'          => [
 				'name' => __( 'Reset Caches', 'code-snippets' ),
 				'type' => 'action',
-				'desc' => __( 'Use this button to manually clear snippets caches.', 'code-snippets' ),
+				'desc' => __( 'Use this button to manually clear snippets caches. Worth doing before switching to an older version of the plugin, if your site uses a persistent object cache.', 'code-snippets' ),
 			],
 			'enable_version_change' => [
 				'name'  => __( 'Version Change', 'code-snippets' ),

--- a/src/php/Settings/settings.php
+++ b/src/php/Settings/settings.php
@@ -11,6 +11,7 @@ use Code_Snippets\Client\Welcome_Client;
 use Code_Snippets\Controller\Cloud_Search_Controller;
 use function add_action;
 use function Code_Snippets\clean_snippets_cache;
+use function Code_Snippets\flush_cache_group;
 use function Code_Snippets\code_snippets;
 use function Code_Snippets\Utils\add_self_option;
 use function Code_Snippets\Utils\get_self_option;
@@ -311,6 +312,11 @@ function process_settings_actions( array $input ): ?array {
 		if ( is_multisite() ) {
 			clean_snippets_cache( code_snippets()->db->get_table_name( true ) );
 		}
+
+		// Deleting known keys cannot reach data written by a different version
+		// of the plugin, which is what needs clearing before a rollback, so the
+		// whole group goes too.
+		flush_cache_group( CACHE_GROUP );
 
 		add_settings_error(
 			OPTION_NAME,

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -123,6 +123,12 @@ function flush_versioned_cache_groups( string $previous_version ): void {
 		flush_cache_group( CACHE_GROUP_BASE . '_' . $previous_version );
 	}
 
+	// Versions before the group was scoped wrote to the unscoped group, and no
+	// version that scopes it ever writes there again. Clearing it means a site
+	// upgrading from 3.10.0 or 3.10.1 sheds the objects that would otherwise
+	// still be waiting to break its next rollback.
+	flush_cache_group( CACHE_GROUP_BASE );
+
 	flush_cache_group( CACHE_GROUP );
 }
 

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -89,6 +89,44 @@ function clean_snippets_cache( string $table_name ) {
 }
 
 /**
+ * Flush an entire cache group, where the object cache supports it.
+ *
+ * Not all persistent cache drop-ins implement group flushing, and the function
+ * itself only exists from WordPress 6.1, so both are checked before use. A
+ * failure is not important: cache groups are scoped to the plugin version, so
+ * flushing is housekeeping rather than something correctness depends on, and
+ * anything left behind is evicted by the cache in its own time.
+ *
+ * @param string $group Cache group to flush.
+ *
+ * @return bool Whether the group was flushed.
+ */
+function flush_cache_group( string $group ): bool {
+	if ( ! function_exists( 'wp_cache_flush_group' ) ||
+	     ! function_exists( 'wp_cache_supports' ) ||
+	     ! wp_cache_supports( 'flush_group' ) ) {
+		return false;
+	}
+
+	return (bool) wp_cache_flush_group( $group );
+}
+
+/**
+ * Flush the cache groups belonging to other versions of the plugin.
+ *
+ * @param string $previous_version Version the site was running beforehand.
+ *
+ * @return void
+ */
+function flush_versioned_cache_groups( string $previous_version ): void {
+	if ( '' !== $previous_version && PLUGIN_VERSION !== $previous_version ) {
+		flush_cache_group( CACHE_GROUP_BASE . '_' . $previous_version );
+	}
+
+	flush_cache_group( CACHE_GROUP );
+}
+
+/**
  * Retrieve a list of snippets from the database.
  * Read operation.
  *

--- a/tests/unit/Core/Versioned_Cache_Test.php
+++ b/tests/unit/Core/Versioned_Cache_Test.php
@@ -76,6 +76,27 @@ class Versioned_Cache_Test extends UnitTestCase {
 	}
 
 	/**
+	 * The legacy unscoped group is cleared on the first upgrade.
+	 *
+	 * Sites coming from 3.10.0 or 3.10.1 have Snippet objects sitting in the
+	 * old unscoped group. Those are what break the next rollback, so upgrading
+	 * to a version that scopes the group has to shed them.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_unscoped_group_is_cleared_on_upgrade(): void {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
+			$this->markTestSkipped( 'Object cache does not support group flushing.' );
+		}
+
+		wp_cache_set( 'all_snippets_wp_snippets', 'objects from 3.10.1', CACHE_GROUP_BASE );
+
+		flush_versioned_cache_groups( '' );
+
+		$this->assertFalse( wp_cache_get( 'all_snippets_wp_snippets', CACHE_GROUP_BASE ) );
+	}
+
+	/**
 	 * An empty previous version is tolerated, as on a fresh install.
 	 *
 	 * @return void

--- a/tests/unit/Core/Versioned_Cache_Test.php
+++ b/tests/unit/Core/Versioned_Cache_Test.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Code_Snippets\Core;
+
+use Code_Snippets\UnitTestCase;
+use function Code_Snippets\flush_cache_group;
+use function Code_Snippets\flush_versioned_cache_groups;
+use const Code_Snippets\CACHE_GROUP;
+use const Code_Snippets\CACHE_GROUP_BASE;
+use const Code_Snippets\PLUGIN_VERSION;
+
+/**
+ * Tests for version-scoped cache groups.
+ *
+ * @group cache
+ */
+class Versioned_Cache_Test extends UnitTestCase {
+
+	/**
+	 * The cache group carries the plugin version.
+	 *
+	 * Snippet objects are cached, and the Snippet class moved namespace in
+	 * 3.10. A version that cannot resolve the stored class fatals on
+	 * unserialize, so two versions must never share a group.
+	 *
+	 * @return void
+	 */
+	public function test_cache_group_is_scoped_to_the_plugin_version(): void {
+		$this->assertSame( CACHE_GROUP_BASE . '_' . PLUGIN_VERSION, CACHE_GROUP );
+		$this->assertStringContainsString( PLUGIN_VERSION, CACHE_GROUP );
+	}
+
+	/**
+	 * A different version reads a different group, so cannot see this data.
+	 *
+	 * @return void
+	 */
+	public function test_another_version_does_not_share_cached_data(): void {
+		wp_cache_set( 'shared_key', 'written by this version', CACHE_GROUP );
+
+		$other_group = CACHE_GROUP_BASE . '_0.0.1';
+
+		$this->assertSame( 'written by this version', wp_cache_get( 'shared_key', CACHE_GROUP ) );
+		$this->assertFalse( wp_cache_get( 'shared_key', $other_group ) );
+	}
+
+	/**
+	 * Flushing a group is safe even when the backend cannot do it.
+	 *
+	 * @return void
+	 */
+	public function test_flushing_a_group_never_errors(): void {
+		wp_cache_set( 'transient_key', 'value', CACHE_GROUP );
+
+		$this->assertIsBool( flush_cache_group( CACHE_GROUP ) );
+	}
+
+	/**
+	 * Flushing on a version change clears the previous version's group.
+	 *
+	 * @return void
+	 */
+	public function test_version_change_clears_the_previous_group(): void {
+		$previous_group = CACHE_GROUP_BASE . '_3.9.6';
+
+		wp_cache_set( 'stale', 'left by the older version', $previous_group );
+		wp_cache_set( 'current', 'ours', CACHE_GROUP );
+
+		flush_versioned_cache_groups( '3.9.6' );
+
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_group' ) ) {
+			$this->assertFalse( wp_cache_get( 'stale', $previous_group ) );
+		} else {
+			$this->markTestSkipped( 'Object cache does not support group flushing.' );
+		}
+	}
+
+	/**
+	 * An empty previous version is tolerated, as on a fresh install.
+	 *
+	 * @return void
+	 */
+	public function test_empty_previous_version_is_tolerated(): void {
+		flush_versioned_cache_groups( '' );
+
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
Downgrading from 3.10 to 3.9.x fatals on any site with a persistent object cache. Reported by hannab in [this thread](https://wordpress.org/support/topic/code-snippets-3-10-0-all-snippets-page-hangs-will-not-load/), who could not roll back to escape a different bug. Discussed with @sheabunge on Discord.

## The bug

```
The script tried to call a method on an incomplete object. Please ensure that the
class definition 'Code_Snippets\Model\Snippet' was loaded before unserialize()
```

Snippet objects are cached, and the class moved namespace in 3.10:

| version | class | file |
| --- | --- | --- |
| 3.9.6 | `Code_Snippets\Snippet` | `php/class-snippet.php` |
| 3.10.x | `Code_Snippets\Model\Snippet` | `php/Model/Snippet.php` |

Both used the same group and keys, and `Plugin.php:96` registers the group as global, so with Redis or Memcached the serialised 3.10 objects outlive the downgrade. The older version then reads a class it cannot resolve and dies before any of its own code runs.

Rolling back is what people do when a release breaks something, so this lands on users already having a bad day. Our own Version Switch feature is one of the ways to trigger it.

## Why flushing alone does not fix it

A flush shipped in 3.10.2 is absent from 3.9.6, and 3.9.6 is the version doing the reading. It reads our cache before any new code of ours can intervene.

Switching the cached payload to arrays has the same shape of problem: 3.9.6 would read an array where it expects an object and fail differently on the same key.

## The fix

Scope the cache group to the plugin version:

```php
const CACHE_GROUP = CACHE_GROUP_BASE . '_' . PLUGIN_VERSION;
```

Old and new never address the same entry, so it stops mattering what shape either one wrote, and it works in both directions without requiring the other version to cooperate. Scoping the group rather than each key covers all 17 call sites without touching them.

Three supporting changes:

- **`Upgrader` reacts to the version changing in either direction** and clears the previous version's group. `do_site_upgrades()` guards on `version_compare( ..., '<' )` so it never fires on a rollback. This is tracked in its own option, because that method leaves its version untouched when downgrading, which would otherwise leave this flushing on every request for as long as the older version ran.
- **Reset Caches now flushes the group.** Deleting known keys cannot reach data written by a different version, which is the case that needs clearing.
- **Group flushing is feature-detected.** `wp_cache_flush_group()` needs WP 6.1 and a drop-in that supports it, and our readme still says `Requires at least: 5.5`. Where unavailable nothing is flushed and the cache evicts in its own time, which is safe because correctness rests on the scoping rather than the flush. No `wp_cache_flush()` fallback, so we never clear an entire site's cache as a side effect.

## Testing

5 unit tests in `Versioned_Cache_Test`. Full suite 162 tests, 0 failures, `phpcs` clean.

Verified end to end on WP 7.1 / PHP 8.5 with a persistent object cache drop-in installed, running the actual downgrade:

| | released 3.10.1 → 3.9.6 | patched → 3.9.6 |
| --- | ---: | ---: |
| All Snippets | **fatal**, 4 KB | clean, 320 KB |
| snippet rows | 0 | **102** |
| group written | `code_snippets` | `code_snippets_3.10.1` |

The baseline reproduces hannab's error verbatim, and the cache dump confirms `Code_Snippets\Model\Snippet` objects being stored under the unscoped group beforehand and the scoped one afterwards.

## Not included

Anyone already on 3.10.0 or 3.10.1 who rolls back still hits this, because their cache was written before any of this existed. `wp cache flush` clears it and remains the support answer for existing installs. Everything here is forward-looking.

Caching arrays rather than objects is still worth doing as hygiene, and @sheabunge noted `Model` already keeps everything in a single `$fields` array so it is largely mechanical. With the group scoped it is no longer needed for correctness, so it is left for a follow-up.
