### PR TITLE
fix: restore the Run Once action for single-use snippets

### DIFF
--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -26,7 +26,12 @@ const RunOnceButton: React.FC<ColumnProps> = ({ snippet }) =>
 	<a
 		className="snippet-execution-button"
 		title={__('Run Once', 'code-snippets')}
-		href={buildUrl(window.location.href, { action: 'run-once', snippet: snippet.id })}
+		href={buildUrl(window.location.href, {
+			action: 'run-once',
+			snippet: snippet.id,
+			network: snippet.network ? 'true' : 'false',
+			_wpnonce: window.CODE_SNIPPETS_MANAGE?.runOnceNonce ?? ''
+		})}
 	>
 		<span className="screen-reader-text">{__('Run Once', 'code-snippets')}</span>
 		<span aria-hidden="true">&nbsp;</span>

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -72,6 +72,7 @@ declare global {
 			cloudSearchPerPage: number
 			isSafeModeActive: boolean
 			bulkDownloadNonce: string
+			runOnceNonce?: string
 			supportsZipDownloads: boolean
 			editorTheme: string
 		}

--- a/src/php/Admin/Menus/Manage/Manage_Menu.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu.php
@@ -5,6 +5,7 @@ namespace Code_Snippets\Admin\Menus\Manage;
 use Code_Snippets\Admin\Contextual_Help;
 use Code_Snippets\Admin\Menus\Admin_Menu;
 use Code_Snippets\Controller\Cloud_Search_Controller;
+use function Code_Snippets\activate_snippet;
 use function Code_Snippets\code_snippets;
 use function Code_Snippets\Settings\get_setting;
 use const Code_Snippets\PLUGIN_FILE;
@@ -46,6 +47,7 @@ class Manage_Menu extends Admin_Menu {
 		new Manage_Menu_Bulk_Download();
 
 		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 500 );
+		add_action( 'admin_notices', [ $this, 'render_run_once_notice' ] );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_menu_css' ) );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_menu_css' ] );
 	}
@@ -178,11 +180,95 @@ class Manage_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Nonce action guarding the run-once request.
+	 */
+	public const RUN_ONCE_NONCE = 'code_snippets_run_once';
+
+	/**
+	 * Run a single-use snippet, when asked to by the snippets list.
+	 *
+	 * Activating the snippet is all that is required: single-use snippets are
+	 * executed and then deactivated again on the next page load, so redirecting
+	 * afterwards both runs the code and returns the snippet to its resting
+	 * state. This mirrors what the list table did before the snippets list
+	 * moved to the REST API, at which point the button was left pointing at a
+	 * URL that nothing handled.
+	 *
+	 * @return void
+	 */
+	private function handle_run_once(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Verified immediately below.
+		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+
+		if ( 'run-once' !== $action ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Verified immediately below.
+		$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, self::RUN_ONCE_NONCE ) || ! code_snippets()->current_user_can() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Verified above.
+		$snippet_id = isset( $_REQUEST['snippet'] ) ? absint( wp_unslash( $_REQUEST['snippet'] ) ) : 0;
+
+		if ( ! $snippet_id ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Verified above.
+		$network = isset( $_REQUEST['network'] ) ? rest_sanitize_boolean( wp_unslash( $_REQUEST['network'] ) ) : null;
+
+		$result = activate_snippet( $snippet_id, $network );
+
+		wp_safe_redirect(
+			add_query_arg(
+				[ 'result' => is_string( $result ) ? 'run-once-failed' : 'executed' ],
+				remove_query_arg( [ 'action', 'snippet', 'network', '_wpnonce', 'result' ] )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Report the outcome of a run-once request.
+	 *
+	 * @return void
+	 */
+	public function render_run_once_notice(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display of an outcome.
+		$result = isset( $_GET['result'] ) ? sanitize_key( wp_unslash( $_GET['result'] ) ) : '';
+
+		if ( 'executed' === $result ) {
+			wp_admin_notice(
+				__( 'Snippet <strong>executed</strong>.', 'code-snippets' ),
+				[
+					'type'               => 'success',
+					'dismissible'        => true,
+					'additional_classes' => [ 'code-snippets-run-once-notice' ],
+				]
+			);
+		} elseif ( 'run-once-failed' === $result ) {
+			wp_admin_notice(
+				__( 'The snippet could not be run. Check that its code is valid and try again.', 'code-snippets' ),
+				[
+					'type'               => 'error',
+					'dismissible'        => true,
+					'additional_classes' => [ 'code-snippets-run-once-notice' ],
+				]
+			);
+		}
+	}
+
+	/**
 	 * Executed when the admin page is loaded.
 	 */
 	public function load() {
 		parent::load();
 
+		$this->handle_run_once();
 		$this->screen_options->load();
 
 		if ( $this->screen_options->is_upsell_view() ) {

--- a/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Assets.php
@@ -100,6 +100,7 @@ class Manage_Menu_Assets {
 			'cloudSearchPerPage'   => Manage_Menu::get_cloud_search_per_page(),
 			'isSafeModeActive'     => Evaluate_Functions::is_safe_mode_active(),
 			'bulkDownloadNonce'    => wp_create_nonce( 'code_snippets_bulk_download' ),
+			'runOnceNonce'         => wp_create_nonce( Manage_Menu::RUN_ONCE_NONCE ),
 			'supportsZipDownloads' => class_exists( 'ZipArchive' ),
 			'editorTheme'          => get_setting( 'editor', 'theme' ),
 			'typeCounts'           => $this->get_snippet_type_counts(),


### PR DESCRIPTION
The Run Once button has done nothing since 3.10.0. Spotted via [this forum thread](https://wordpress.org/support/topic/sort-order-set-on-settings-page-doesnt-work-anymore/), where hemligg mentioned in passing that the confirmation was missing. It is worse than that: the snippet never runs.

## The bug

The button is still rendered and still links to `action=run-once`, but the code that handled it lived in `class-list-table.php`, removed when the list moved to the REST API. In released 3.10.1 the string `run-once` appears **only in the JavaScript**. No PHP responds to it.

The two URLs do not even match any more. The list table rendered `action=run-once&id=1&scope=single-use&_wpnonce=…`; the React button builds `action=run-once&snippet=1` — different parameter name, no nonce.

Measured on a clean install with a single-use snippet that writes an option when it runs:

| | 3.9.6 | 3.10.1 |
| --- | --- | --- |
| Notice | `Snippet **executed**.` | none |
| Snippet actually ran | **yes**, option written | **no**, still unset |
| Self-deactivated after | yes | n/a |

It fails silently. The page reloads with no notice and no error, so it looks like it worked. Single-use snippets tend to be one-off migrations or fixes, which makes that a bad way to fail.

## The fix

Handle the request again, on the manage screen's `load-` hook.

Activating the snippet is all that is required: single-use snippets execute and then deactivate themselves on the next page load, so redirecting afterwards both runs the code and returns the snippet to its resting state. This is what the list table did (`perform_action( $id, 'activate' )`), and it matters for honesty of the message — the snippet has genuinely run by the time the notice appears, rather than merely being queued.

The old per-row nonce came from the list table and no longer exists, so the button sends a single localised nonce instead, checked alongside the existing capability check.

Also adds a notice for the case where activation fails validation, which previously had no feedback either.

## Testing

Verified end to end on WP 7.1 / PHP 8.5 against released 3.10.1 with the fix applied:

| | result |
| --- | --- |
| Notice | `Snippet **executed**.` |
| Marker option | written — the snippet ran |
| Active flag afterwards | `0`, self-deactivated |
| Invalid nonce | nothing happens, no notice, snippet does not run |
| Logged out | 302 to login, snippet does not run |

`phpcs` and `eslint` clean.

## Note on target

Branched from `core` per the hotfix policy, since this is a bug in released 3.10.x. Needs syncing into Pro afterwards, as the button exists in both editions.
