### PR TITLE
fix: keep saving possible after the session expires

### DIFF
--- a/src/js/hooks/useRestAPI.tsx
+++ b/src/js/hooks/useRestAPI.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import axios from 'axios'
 import { createContextHook } from '../utils/bootstrap'
-import { REST_API_AXIOS_CONFIG, applyMethodOverride } from '../utils/restAPI'
+import { REST_API_AXIOS_CONFIG, applyMethodOverride, applyRestNonce, listenForNonceRefresh } from '../utils/restAPI'
 import type { PropsWithChildren } from 'react'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
@@ -60,7 +60,9 @@ const [Context, useRestAPI] = createContextHook<RestAPIContext>('useRestAPI')
 export const WithRestAPIContext: React.FC<PropsWithChildren> = ({ children }) => {
 	const axiosInstance = useMemo(() => {
 		const instance = axios.create(REST_API_AXIOS_CONFIG)
+		instance.interceptors.request.use(applyRestNonce)
 		instance.interceptors.request.use(applyMethodOverride)
+		listenForNonceRefresh()
 		return instance
 	}, [])
 

--- a/src/js/hooks/useSubmitSnippet.tsx
+++ b/src/js/hooks/useSubmitSnippet.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n'
 import { isAxiosError } from 'axios'
 import React, { useCallback } from 'react'
+import { describeRequestError } from '../utils/errors'
 import { useSnippetForm } from '../components/EditMenu/SnippetForm/WithSnippetFormContext'
 import { createSnippetObject, isCondition } from '../utils/snippets/snippets'
 import { buildUrl } from '../utils/urls'
@@ -113,8 +114,8 @@ export const useSubmitSnippet = (): UseSubmitSnippet => {
 					: api.update({ ...request, id }))
 
 				return response.id ? createSnippetObject(response) : undefined
-			} catch (error) {
-				return isAxiosError(error) ? error.message : undefined
+			} catch (error: unknown) {
+				return isAxiosError(error) ? describeRequestError(error) : undefined
 			} finally {
 				setIsWorking(false)
 			}

--- a/src/js/types/Window.ts
+++ b/src/js/types/Window.ts
@@ -12,6 +12,13 @@ declare global {
 		readonly wp: {
 			readonly editor?: WordPressEditor
 			readonly codeEditor?: WordPressCodeEditor
+			readonly hooks?: {
+				addAction: (
+					hookName: string,
+					namespace: string,
+					callback: (data: { rest_nonce?: string }) => void
+				) => void
+			}
 		}
 		readonly pagenow?: string
 		readonly ajaxurl: string

--- a/src/js/utils/errors.ts
+++ b/src/js/utils/errors.ts
@@ -20,3 +20,36 @@ export const unpackErrorResponse = (error: unknown): string => {
 
 	return __('An unknown error occurred.', 'code-snippets')
 }
+
+/**
+ * Explain a failed request in terms the reader can act on.
+ *
+ * An expired session is the common case worth naming: the snippet editor is a
+ * screen people leave open, and once the session lapses WordPress rejects every
+ * write with a 403 that says only "Cookie check failed". Reporting the raw
+ * status left people believing the plugin had ignored them.
+ */
+export const describeRequestError = (error: unknown): string => {
+	if (!isAxiosError(error)) {
+		return unpackErrorResponse(error)
+	}
+
+	if (!error.response) {
+		return __(
+			'The request did not reach your site. Check your connection, or whether a security plugin is blocking it.',
+			'code-snippets'
+		)
+	}
+
+	const data: unknown = error.response.data
+	const code = data && 'object' === typeof data && 'code' in data ? String(data.code) : ''
+
+	if ('rest_cookie_invalid_nonce' === code || 'rest_not_logged_in' === code) {
+		return __(
+			'You have been signed out, so nothing was saved. Sign in again in another tab, then save. Your changes are still here.',
+			'code-snippets'
+		)
+	}
+
+	return unpackErrorResponse(error)
+}

--- a/src/js/utils/restAPI.ts
+++ b/src/js/utils/restAPI.ts
@@ -41,9 +41,54 @@ export const applyMethodOverride = (config: InternalAxiosRequestConfig): Interna
 	return config
 }
 
+/**
+ * The REST nonce to authenticate the next request with.
+ *
+ * Held in a variable rather than baked into the axios config, because the value
+ * the page was rendered with does not stay valid. A nonce expires with the
+ * session, and the snippet editor is a screen people leave open for a long
+ * time. Once it lapsed, every save failed with a 403 and the only cure was
+ * reloading the page, which loses whatever was being written.
+ */
+let restNonce = window.CODE_SNIPPETS?.restAPI.nonce
+
+/**
+ * Keep the REST nonce current for as long as the page is open.
+ *
+ * WordPress already sends a freshly minted nonce with every Heartbeat response,
+ * from `wp_refresh_heartbeat_nonces()`. Core applies it to `wpApiSettings`,
+ * which our screens do not enqueue, so the value went unused. Listening for the
+ * tick ourselves means an editor left open stays able to save.
+ */
+export const listenForNonceRefresh = () => {
+	// Heartbeat also fires the tick through the hooks API, which avoids
+	// depending on jQuery being present and typed.
+	window.wp.hooks?.addAction(
+		'heartbeat.tick',
+		'code-snippets/refresh-rest-nonce',
+		(data: { rest_nonce?: string }) => {
+			if (data.rest_nonce) {
+				restNonce = data.rest_nonce
+			}
+		}
+	)
+}
+
+/**
+ * Attach the current nonce to an outgoing request.
+ *
+ * Read per request, so that a nonce refreshed since page load is actually used.
+ */
+export const applyRestNonce = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+	if (restNonce) {
+		config.headers.set('X-WP-Nonce', restNonce)
+	}
+
+	return config
+}
+
 export const REST_API_AXIOS_CONFIG: AxiosRequestConfig = {
 	headers: {
-		'X-WP-Nonce': window.CODE_SNIPPETS?.restAPI.nonce,
 		'Access-Control': window.CODE_SNIPPETS?.restAPI.cloud.token
 	}
 }


### PR DESCRIPTION
Fixes the report in [Changing snippet's code won't take effect without refreshing the page](https://wordpress.org/support/topic/changing-snippets-code-wont-take-effect-without-refreshing-the-page/). @VerdiHeinz diagnosed it correctly on the thread — an expired session behind an open editor — and this is that fix.

> a **Save** button should save, not merely look confident while doing nothing

## Reproducing it

Open a snippet for editing, destroy the session server-side, edit the code, press Save:

```
POST …/code-snippets/v1/snippets/1308 → 403 Forbidden
{"code":"rest_cookie_invalid_nonce","message":"Cookie check failed"}
```

## Two separate faults

**The nonce could never be replaced.** It was read once at module load and baked into the axios config for the life of the page:

```ts
export const REST_API_AXIOS_CONFIG: AxiosRequestConfig = {
	headers: { 'X-WP-Nonce': window.CODE_SNIPPETS?.restAPI.nonce, … }
}
```

So once it lapsed, the page presented a dead nonce forever and reloading was the only cure — which is exactly the thread's title, and it costs you whatever you were writing.

**WordPress already solves this and we weren't listening.** `wp_refresh_heartbeat_nonces()` puts a freshly minted `rest_nonce` in *every* Heartbeat response. Core applies it in `heartbeat.js`:

```js
if ( response.rest_nonce && typeof window.wpApiSettings === 'object' ) {
	window.wpApiSettings.nonce = response.rest_nonce;
}
```

`wpApiSettings` is not enqueued on our screens, so that value was arriving and being thrown away on every tick.

**The failure was reported uselessly.** The server names the cause, `rest_cookie_invalid_nonce`, and `useSubmitSnippet` discarded it in favour of the axios message. The user saw:

> Could not update snippet. **Request failed with status code 403**

## The fix

- The nonce is held in a variable and attached **per request**, so it can be replaced.
- A `heartbeat.tick` listener updates it, so an editor left open stays able to save.
- An expired session is recognised and explained: *"You have been signed out, so nothing was saved. Sign in again in another tab, then save. Your changes are still here."*

## Verified

With the editor open and the session destroyed:

| | before | after |
| --- | --- | --- |
| Message | `Request failed with status code 403` | names the expired session and says nothing was saved |
| Editor contents | kept | kept |
| **Recovery** | **reload only** | **sign in elsewhere, next tick restores it** |

The recovery path was tested end to end: signed in via a second tab, forced a Heartbeat tick, pressed Save, got *"Snippet updated."* — and confirmed in the database that the edited code had landed, **with the page never reloaded**.

`eslint` clean, 0 tsc errors in our source, 157 PHP tests passing.

## Also raised on that thread, not addressed here

namrur mentioned three UI points, and one is worth recording because I measured it: the notice renders around **773px** down the page, so on a laptop viewport it sits below the fold — you press Save and appear to get nothing. They also asked for one save button instead of two, and for activation to be governed solely by the toggle. Those are design decisions rather than bugs, so I have left them out.
