### PR TITLE
fix: correct the nonce argument in the version switch AJAX handlers

### DIFF
--- a/src/php/Settings/Version_Switch.php
+++ b/src/php/Settings/Version_Switch.php
@@ -423,7 +423,7 @@ class Version_Switch {
 	 * @return void
 	 */
 	public static function ajax_switch_version(): void {
-		check_ajax_referer( 'code_snippets_version_switch', sanitize_text_field( wp_unslash( $_POST['nonce'] ?? '' ) ) );
+		check_ajax_referer( 'code_snippets_version_switch', 'nonce' );
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			wp_send_json_error( [ 'message' => __( 'You do not have permission to update plugins.', 'code-snippets' ) ] );
@@ -467,7 +467,7 @@ class Version_Switch {
 	 * @return void
 	 */
 	public static function ajax_refresh_versions(): void {
-		check_ajax_referer( 'code_snippets_refresh_versions', sanitize_text_field( wp_unslash( $_POST['nonce'] ?? '' ) ) );
+		check_ajax_referer( 'code_snippets_refresh_versions', 'nonce' );
 
 		if ( ! code_snippets()->current_user_can() ) {
 			wp_send_json_error( [ 'message' => __( 'You do not have permission to manage options.', 'code-snippets' ) ] );


### PR DESCRIPTION
Switching or rolling back the plugin version does nothing. Picking a version and clicking **Switch Version** shows "An error occurred."; **Refresh Available Versions** resets its own label without any message at all. Reproduced on a live site as well as locally.

`check_ajax_referer( $action, $query_arg )` treats `$query_arg` as the *name of the request key* to read the nonce from. Both handlers passed the nonce's value there instead, so WordPress looked for `$_REQUEST['<the nonce value>']`, fell through to `_ajax_nonce` and `_wpnonce` — neither of which the front end sends — and verified an empty string. Every request was rejected, valid nonce or not.

`Promotion_Base::dismiss_promotion_ajax_handler()` already does this correctly with `check_ajax_referer( self::AJAX_ACTION, 'nonce' )`, which is the form used here.

## Testing

Against `admin-ajax.php` as a logged-in admin:

| | before | after |
| --- | --- | --- |
| refresh, valid nonce | `403` | `200 success` |
| refresh, invalid nonce | `403` | `403` |
| switch, valid nonce | `403` | reaches the handler |
| switch, invalid nonce | `403` | `403` |

The switch case was exercised with an empty `target_version`, so the request passes the nonce and capability checks and stops at validation — proving the gate opens without installing anything.

Driven through the real UI afterwards: the dropdown populates with all 62 versions from wordpress.org and both buttons respond. phpcs clean.

Note this sits behind **Settings → Debug → Enable version change**, which is off by default, so only people who switched it on will have hit it.
