### PR TITLE
fix: stop aliased field names warning when reading modified fields

### DIFF
--- a/src/php/Model/Model.php
+++ b/src/php/Model/Model.php
@@ -91,7 +91,11 @@ abstract class Model {
 		return array_filter(
 			$this->get_fields(),
 			function ( $value, $field ) {
-				return $value && $value !== static::$default_values[ $field ];
+				// The field list includes aliases, which have no entry of their own
+				// in the defaults. Compare against the field an alias resolves to,
+				// so reading a snippet built from alias keys does not warn.
+				$default = static::$default_values[ static::resolve_field_name( $field ) ] ?? null;
+				return $value && $value !== $default;
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/tests/unit/Model/Snippet_Test.php
+++ b/tests/unit/Model/Snippet_Test.php
@@ -66,4 +66,29 @@ class Snippet_Test extends UnitTestCase {
 
 		$this->assertNull( $snippet->modified_iso );
 	}
+
+	/**
+	 * Reading modified fields from a snippet built with alias keys does not warn.
+	 *
+	 * The field list includes aliases such as 'description' and 'language', which
+	 * have no entry of their own in the defaults. Importing builds snippets from
+	 * exactly those keys, so every imported snippet raised a PHP warning. Warnings
+	 * are converted to exceptions for this suite, so a regression fails here.
+	 *
+	 * @return void
+	 */
+	public function test_get_modified_fields_handles_aliased_field_names(): void {
+		$snippet = new Snippet(
+			[
+				'name'        => 'Aliased fields',
+				'description' => 'set through the alias',
+				'language'    => 'php',
+			]
+		);
+
+		$modified = $snippet->get_modified_fields();
+
+		$this->assertArrayHasKey( 'desc', $modified );
+		$this->assertSame( 'set through the alias', $modified['desc'] );
+	}
 }


### PR DESCRIPTION
Importing snippets writes two PHP warnings per snippet on a site with `WP_DEBUG` on:

```
PHP Warning: Undefined array key "description" in .../php/Model/Model.php on line 94
PHP Warning: Undefined array key "language"    in .../php/Model/Model.php on line 94
```

Found while testing a 3.10.2 build. It reproduces on released 3.10.1 as well.

## Cause

`get_allowed_fields()` returns the real field names **plus their aliases**:

```php
return array_merge( array_keys( $this->fields ), array_keys( static::$field_aliases ) );
```

So `get_fields()` emits an entry for both `desc` and `description`, and for both `lang` and `language`. `$default_values` only holds the real names, so `get_modified_fields()` looked up a key that was never there.

The import path builds snippets from exactly those alias keys — `File_Import_REST_Controller` maps `desc`/`description` straight out of the file — which is why importing triggers it reliably.

## Fix

Compare against the field an alias resolves to, using the existing `resolve_field_name()`.

Behaviour is unchanged. Aliased values were previously compared against a missing key (`null`) and returned whenever truthy; they are now compared against the real field's default (`''`) and are still returned whenever truthy. Verified on a live site before and after — same five modified fields, both `desc` and `description` still present, warnings 2 → 0.

## Testing

Added a regression test. The suite converts warnings to exceptions, so it errors without the fix and passes with it:

```
without the fix:  ERRORS!  Tests: 1, Errors: 1   (Undefined array key "description")
with the fix:     OK       Tests: 4, Assertions: 6
```

Full suite 158 tests / 0 failures. `lint:php` and `lint:js` both clean.

Reproduced and confirmed fixed on a clean WordPress 7.1 / PHP 8.1 install with the plugin installed from a built zip, rather than from a development checkout.
