### PR TITLE
chore: migrate test runners to Blacksmith

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   lint:
     name: stylelint, eslint, phpcs
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/phpunit-test.yml
+++ b/.github/workflows/phpunit-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   phpunit-test:
     name: PHPUnit tests (PHP ${{ inputs.php-version }})
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_TESTS_DIR: /tmp/wordpress-tests-lib

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   playwright-test:
     name: Playwright tests (${{ inputs.test-mode == 'default' && 'Default Mode' || 'File-based Execution' }})
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       mysql:
         image: mysql:8.0


### PR DESCRIPTION
Migrate the CI runners to Blacksmith.

## Change

`runs-on` for the test runners and the lint job:

- `PHPUnit Test Runner` (`phpunit-test.yml`): `ubuntu-22.04` -> `blacksmith-2vcpu-ubuntu-2404`
- `Playwright Test Runner` (`playwright-test.yml`): `ubuntu-22.04` -> `blacksmith-4vcpu-ubuntu-2404`
- `(Lint): CSS, JS, PHP` (`lint.yml`): `ubuntu-22.04` -> `blacksmith-2vcpu-ubuntu-2404`

PHP tests and lint at 2 vCPU, Playwright at 4 vCPU. Build, release, and the result-summary jobs remain on GitHub-hosted runners for now. This migration is intended to propagate to the pro repository next.
