### PR TITLE
fix: strip unprefixed vendor namespaces from the autoloader

### DIFF
--- a/src/php/Core/load.php
+++ b/src/php/Core/load.php
@@ -59,7 +59,9 @@ $autoloader = require dirname( __DIR__, 2 ) . '/vendor/autoload.php';
 if ( $autoloader instanceof ClassLoader ) {
 	$vendor_prefix = __NAMESPACE__ . '\\Vendor\\';
 
-	foreach ( $autoloader->getPrefixesPsr4() as $namespace => $paths ) {
+	$prefixes = $autoloader->getPrefixesPsr4();
+
+	foreach ( $prefixes as $namespace => $paths ) {
 		// Remove any non-Code_Snippets namespace that has a corresponding prefixed version.
 		if ( false === strpos( $namespace, $vendor_prefix ) ) {
 			if ( isset( $prefixes[ $vendor_prefix . $namespace ] ) ) {

--- a/tests/unit/Core/Autoloader_Prefixes_Test.php
+++ b/tests/unit/Core/Autoloader_Prefixes_Test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Code_Snippets\Core;
+
+use Code_Snippets\UnitTestCase;
+use Composer\Autoload\ClassLoader;
+
+/**
+ * Tests for the Composer autoloader namespace cleanup performed in load.php.
+ */
+class Autoloader_Prefixes_Test extends UnitTestCase {
+
+	/**
+	 * Retrieve the plugin's registered Composer autoloader, if there is one.
+	 *
+	 * @return ClassLoader|null
+	 */
+	private function get_plugin_autoloader(): ?ClassLoader {
+		$registered = spl_autoload_functions();
+
+		foreach ( is_array( $registered ) ? $registered : [] as $callback ) {
+			if ( is_array( $callback ) && $callback[0] instanceof ClassLoader ) {
+				$prefixes = $callback[0]->getPrefixesPsr4();
+
+				if ( isset( $prefixes['Code_Snippets\\'] ) ) {
+					return $callback[0];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Vendor packages are prefixed by Imposter, but Composer still registers the
+	 * original namespace against the same directory. Left in place, our autoloader
+	 * answers for the unprefixed name, includes the prefixed file a second time,
+	 * and PHP raises "cannot declare interface, because the name is already in use"
+	 * on any site running another plugin that bundles the same library.
+	 *
+	 * @return void
+	 */
+	public function test_no_unprefixed_vendor_namespace_remains_registered(): void {
+		$autoloader = $this->get_plugin_autoloader();
+
+		if ( ! $autoloader ) {
+			$this->markTestSkipped( 'The plugin Composer autoloader is not registered in this environment.' );
+		}
+
+		$vendor_prefix = 'Code_Snippets\\Vendor\\';
+		$prefixes      = $autoloader->getPrefixesPsr4();
+		$leftovers     = [];
+
+		foreach ( array_keys( $prefixes ) as $namespace ) {
+			if ( false === strpos( $namespace, $vendor_prefix ) &&
+			     isset( $prefixes[ $vendor_prefix . $namespace ] ) &&
+			     ! empty( $prefixes[ $namespace ] ) ) {
+				$leftovers[] = $namespace;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$leftovers,
+			'Unprefixed vendor namespaces are still registered: ' . implode( ', ', $leftovers )
+		);
+	}
+}


### PR DESCRIPTION
Fixes a stale-namespace collision in the vendor autoloader cleanup in `src/php/Core/load.php`. The cleanup loop that removes unprefixed Composer PSR-4 namespace entries left behind by Imposter's prefixing step referenced an unassigned variable, so the removal never ran. Left in place, a bundled vendor library stays reachable under both its prefixed and unprefixed namespace, which can fatal with a duplicate-declaration error when another plugin or theme provides the same library unprefixed.

## Changes

- Assign the autoloader's PSR-4 prefix list to a variable before the cleanup loop, so the existing removal logic executes as intended.
- Add `Autoloader_Prefixes_Test`, asserting no unprefixed vendor namespace remains registered alongside a prefixed counterpart.

## Testing

Covered by the new PHPUnit test; full PHPUnit suite passes.
