### PR TITLE
fix: apply the row truncation Screen Option to snippet names (3.10.2)

### DIFF
--- a/src/css/common/list-table/_layout.scss
+++ b/src/css/common/list-table/_layout.scss
@@ -278,9 +278,11 @@
 		text-align: start;
 	}
 
-	// Snippet names always stay on a single line, truncating gracefully;
-	// the full name is exposed through the title attribute.
-	td.column-name > .snippet-name {
+	// Names and descriptions are both governed by the "Truncate long snippet
+	// names and descriptions" Screen Option. When it is off, the full name is
+	// shown; when on, it stays on a single line and the full value remains
+	// available through the title attribute.
+	&.truncate-row-values td.column-name > .snippet-name {
 		display: block;
 		max-inline-size: min(15rem, 30vw);
 		white-space: nowrap;


### PR DESCRIPTION
Retarget of #495 onto the release branch. Same commit, cherry-picked, so it applies without dragging in unrelated `core-beta` changes to the test files.

Reported on Discord against 3.10.1: the **Truncate long snippet names and descriptions** Screen Option only affects the Description column. Snippet names stay truncated whether the option is on or off, which makes long names hard to tell apart. If the Description column is hidden, toggling the option appears to do nothing at all.

The reporter identified the cause themselves, and they were right.

## Cause

The option toggles a `truncate-row-values` class on the list table, but only the description rule was scoped to it:

```scss
td.column-name > .snippet-name { … }                                    // unconditional
&.truncate-row-values td.column-desc .snippet-description-content { … } // scoped
```

So names were always clipped to `min(15rem, 30vw)` regardless of the setting. The class itself toggles correctly — it simply never governed the Name column.

## Fix

Scope the name rule to the same class, so the option governs both values as its label promises.

## Testing

Measured on the same row, with a deliberately long (88 character) snippet name:

| | before | after |
| --- | --- | --- |
| option on | `max-inline-size: 240px`, clipped | `max-inline-size: 240px`, clipped |
| option off | `max-inline-size: 240px`, clipped | `max-inline-size: none`, full name shown |

With the option off the name now wraps and is fully readable; the row grows by one line, which is the same behaviour the Description column already has. With it on, nothing changes. Verified by toggling the Screen Option through the UI rather than by forcing the class, on a clean WordPress 7.1 install with the plugin installed from a built zip. stylelint clean.

## Note

This covers the table view only. The card/grid view never receives the `truncate-row-values` class, and its truncation is structural — a long name would otherwise push the header icons out of the card. That looks deliberate, so it is left alone here.
