### PR TITLE
ci: sync the stable release into its beta branch on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,28 @@ jobs:
 
           echo "::notice::Successfully dispatched core to pro sync"
 
+  sync-beta:
+    # Sync the stable release into its beta branch (core -> core-beta, pro -> pro-beta).
+    # Runs for both editions; pre-release tags are skipped by the downstream workflow.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch release-to-beta sync workflow
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_PAT }}
+        run: |
+          echo "::notice::Dispatching release-to-beta sync for ${{ github.event.release.tag_name }}"
+
+          if ! gh workflow run "sync-release-to-beta.yml" \
+            --repo "codesnippetspro/.github-private" \
+            --ref main \
+            --field repo="${{ github.repository }}" \
+            --field tag="${{ github.event.release.tag_name }}"; then
+            echo "::error::Failed to dispatch sync-release-to-beta.yml"
+            exit 1
+          fi
+
+          echo "::notice::Successfully dispatched release-to-beta sync"
+
   deploy:
     needs: [build, upload]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `sync-beta` job to the release workflow so that, when a stable release is published, the released branch is synced into its beta branch: `core` into `core-beta`, and `pro` into `pro-beta`.

- Runs on the release event for both editions; pre-release tags are skipped.
- A clean merge is pushed to the beta branch directly.
- A conflict, or a push rejected because the beta branch moved, opens a pull request into the beta branch for manual resolution instead of failing the run.
