### PR TITLE
ci: fix release-gate exit code and rename status to Release Checklist

### DIFF
--- a/.github/actions/release-gate/action.yml
+++ b/.github/actions/release-gate/action.yml
@@ -1,5 +1,5 @@
-name: 'Release PR Gate'
-description: 'Evaluate a release pull request and post the "Release PR Gate" commit status. Defers (posts nothing) while required checks are still running.'
+name: 'Release Checklist'
+description: 'Evaluate a release pull request and post the "Release Checklist" commit status. Defers (posts nothing) while required checks are still running.'
 
 inputs:
   token:
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Evaluate and post Release PR Gate status
+    - name: Evaluate and post Release Checklist status
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -19,7 +19,7 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         PR_BODY: ${{ github.event.pull_request.body }}
-        CONTEXT: 'Release PR Gate'
+        CONTEXT: 'Release Checklist'
       run: |
         set -uo pipefail
 
@@ -32,7 +32,7 @@ runs:
         post() { # post <state> <description>
           gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$1" -f context="$CONTEXT" -f description="$2" >/dev/null
-          echo "::notice::Release PR Gate -> $1: $2"
+          echo "::notice::Release Checklist -> $1: $2"
         }
 
         # The test suites only run when the run-tests label is present; without it

--- a/.github/actions/release-gate/action.yml
+++ b/.github/actions/release-gate/action.yml
@@ -39,7 +39,7 @@ runs:
         # there is nothing to gate on, so flag it rather than silently passing.
         if ! [[ " $PR_LABELS " == *" run-tests "* ]]; then
           post failure "Add the run-tests label so the test suites run."
-          exit 0
+          exit 1
         fi
 
         # Latest conclusion of each required summary check for the head commit.
@@ -65,13 +65,13 @@ runs:
 
         if [ "$failed" = true ]; then
           post failure "Required CI checks are not all passing."
-          exit 0
+          exit 1
         fi
 
         # All required checks are green. Validate the release PR itself.
         case "$BASE_REF" in
           core|core-beta|pro|pro-beta) ;;
-          *) post failure "Base branch '$BASE_REF' must be core, core-beta, pro or pro-beta."; exit 0 ;;
+          *) post failure "Base branch '$BASE_REF' must be core, core-beta, pro or pro-beta."; exit 1 ;;
         esac
 
         # Parse the two "Release verification" checkboxes, fence-aware so text
@@ -90,7 +90,7 @@ runs:
 
         if [ "$total" -ne 2 ] || [ "$checked" -ne 2 ]; then
           post failure "Tick both release-verification checkboxes ($checked/$total approved)."
-          exit 0
+          exit 1
         fi
 
         post success "Required checks green and release verification approved."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run PHP CS
         run: npm run lint:php
 
-  # Post the Release PR Gate status once lint has concluded. Runs for release
+  # Post the Release Checklist status once lint has concluded. Runs for release
   # PRs only; defers if the other suites are still running (see the action).
   release-gate:
     needs: [lint]
@@ -101,7 +101,7 @@ jobs:
         with:
           sparse-checkout: .github/actions/release-gate
 
-      - name: Release PR gate
+      - name: Release Checklist
         uses: ./.github/actions/release-gate
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,6 +1,6 @@
 name: "(Pull Request): Merge Gate"
 
-# Re-evaluates the Release PR Gate on pull-request events that change the gate's
+# Re-evaluates the Release Checklist on pull-request events that change the gate's
 # inputs (checkbox edits, label changes). The gate itself defers while the test
 # suites are still running, so this never races them; the after-tests verdict is
 # posted by the release-gate jobs in the test workflows.
@@ -26,7 +26,7 @@ jobs:
         with:
           sparse-checkout: .github/actions/release-gate
 
-      - name: Release PR gate
+      - name: Release Checklist
         uses: ./.github/actions/release-gate
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -273,7 +273,7 @@ jobs:
         if: needs.phpunit.result != 'success'
         run: exit 1
 
-  # Post the Release PR Gate status once the PHPUnit summary has concluded.
+  # Post the Release Checklist status once the PHPUnit summary has concluded.
   # Runs for release PRs only; defers if other required suites are still running.
   release-gate:
     needs: [test-result]
@@ -287,7 +287,7 @@ jobs:
         with:
           sparse-checkout: .github/actions/release-gate
 
-      - name: Release PR gate
+      - name: Release Checklist
         uses: ./.github/actions/release-gate
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -334,7 +334,7 @@ jobs:
         if: ${{ (needs.playwright-default.result != 'success' && needs.playwright-default.result != 'skipped') || (needs.playwright-file-based-execution.result != 'success' && needs.playwright-file-based-execution.result != 'skipped') }}
         run: exit 1
 
-  # Post the Release PR Gate status once the Playwright summary has concluded.
+  # Post the Release Checklist status once the Playwright summary has concluded.
   # Runs for release PRs only; defers if other required suites are still running.
   release-gate:
     needs: [test-result]
@@ -348,7 +348,7 @@ jobs:
         with:
           sparse-checkout: .github/actions/release-gate
 
-      - name: Release PR gate
+      - name: Release Checklist
         uses: ./.github/actions/release-gate
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #509. Two changes to the release gate.

**Exit code.** The gate posts its verdict as a commit status, but the `release-gate` job always exited 0 — so on a failing verdict (a required check failed, wrong base branch, or unticked release-verification checkboxes) the *status* went red while the *job* check stayed green, reading as a false pass. The job now exits non-zero on a failure verdict (missing `run-tests`, a failing required check, wrong base branch, or unticked checkboxes). Deferrals (required suites still running) and successes still exit 0 and stay green.

**Rename.** The commit-status context is renamed from `Release PR Gate` to `Release Checklist`, along with the action name, step names, and comments. If a branch-protection required check references the old context name, update it to `Release Checklist`.
