### PR TITLE
ci: keep release-gate job green and fix skipped-check aggregation

### DIFF
--- a/.github/actions/release-gate/action.yml
+++ b/.github/actions/release-gate/action.yml
@@ -39,14 +39,19 @@ runs:
         # there is nothing to gate on, so flag it rather than silently passing.
         if ! [[ " $PR_LABELS " == *" run-tests "* ]]; then
           post failure "Add the run-tests label so the test suites run."
-          exit 1
+          exit 0
         fi
 
-        # Latest conclusion of each required summary check for the head commit.
+        # Conclusion of each required summary check for the head commit. A name
+        # can appear more than once on a SHA (e.g. a skipped run from one event
+        # plus a real run from another), so prefer the latest NON-skipped run and
+        # only fall back to a skipped one when that is all there is.
         runs_json=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --paginate 2>/dev/null || echo '{}')
         state_of() {
-          printf '%s' "$runs_json" | jq -r --arg n "$1" \
-            '[.check_runs[] | select(.name == $n)] | last // {} | "\(.status // "missing")|\(.conclusion // "")"'
+          printf '%s' "$runs_json" | jq -r --arg n "$1" '
+            ([.check_runs[] | select(.name == $n)] | sort_by(.completed_at // "")) as $all
+            | (($all | map(select(.conclusion != "skipped")) | last) // ($all | last) // {})
+            | "\(.status // "missing")|\(.conclusion // "")"'
         }
         pending=false; failed=false
         for name in "stylelint, eslint, phpcs" "PHPUnit - Test Results Summary" "Playwright - Test Results Summary"; do
@@ -65,13 +70,13 @@ runs:
 
         if [ "$failed" = true ]; then
           post failure "Required CI checks are not all passing."
-          exit 1
+          exit 0
         fi
 
         # All required checks are green. Validate the release PR itself.
         case "$BASE_REF" in
           core|core-beta|pro|pro-beta) ;;
-          *) post failure "Base branch '$BASE_REF' must be core, core-beta, pro or pro-beta."; exit 1 ;;
+          *) post failure "Base branch '$BASE_REF' must be core, core-beta, pro or pro-beta."; exit 0 ;;
         esac
 
         # Parse the two "Release verification" checkboxes, fence-aware so text
@@ -90,7 +95,7 @@ runs:
 
         if [ "$total" -ne 2 ] || [ "$checked" -ne 2 ]; then
           post failure "Tick both release-verification checkboxes ($checked/$total approved)."
-          exit 1
+          exit 0
         fi
 
         post success "Required checks green and release verification approved."


### PR DESCRIPTION
Follow-up to #510. Two corrections to the `Release Checklist` gate.

**Job exit code (reverts #510's exit-1 change).** The `release-gate` job only *posts* the `Release Checklist` commit status — the verdict belongs in that status, not in the job's exit code. Exiting non-zero on a failure verdict turned the reporter workflows (lint/phpunit/playwright/merge-gate) red and duplicated the one meaningful status. The failure branches exit 0 again; the job is green whenever it evaluated and posted. Branch protection should require the `Release Checklist` **status** as the gate.

**Check aggregation (real bug).** A summary check can appear more than once on a head SHA — a `skipped` run from one event plus the real run from another. The old `last` aggregation could pick the `skipped` duplicate and report a green release as failing (seen on a recent release run: PHPUnit/Playwright summaries were `success` but a `skipped` twin shadowed them → false "CI not passing"). `state_of` now prefers the latest **non-skipped** run per check name, falling back to skipped only when that is all there is.
