### PR TITLE
chore: strip redundant blank lines between list items in changelog/readme linters

### DIFF
--- a/scripts/linters/lint-changelog.ts
+++ b/scripts/linters/lint-changelog.ts
@@ -24,8 +24,10 @@
  * Lists
  *   - Items start with "* " (not "- ")
  *   - No trailing whitespace
+ *   - No blank lines between consecutive list items
  *
  * Spacing
+ *   - No leading blank lines before the title
  *   - Exactly 1 blank line before every ## heading (not before the first one)
  *   - Exactly 1 blank line after every # and ## headings
  *   - No blank lines after ### headings
@@ -54,6 +56,33 @@ const collapseBlankLines = (lines: string[]): string[] => {
 		if (blank && prevBlank) {continue}
 		out.push(l)
 		prevBlank = blank
+	}
+	return out
+}
+
+/** Remove blank lines before the first content line. */
+const stripLeadingBlanks = (lines: string[]): string[] => {
+	let i = 0
+	while (i < lines.length && '' === lines[i].trim()) {i += 1}
+	return lines.slice(i)
+}
+
+/**
+ * Drop blank lines that sit between two list items. Bullets accumulate stray
+ * blank lines over successive edits; consecutive items should be contiguous.
+ */
+const removeBlanksBetweenListItems = (lines: string[]): string[] => {
+	const isItem = (l: string): boolean => /^\s*[*-] /.test(l)
+	const out: string[] = []
+	for (let i = 0; i < lines.length; i += 1) {
+		if ('' === lines[i].trim()) {
+			let j = i + 1
+			while (j < lines.length && '' === lines[j].trim()) {j += 1}
+			const prev = out[out.length - 1]
+			const next = j < lines.length ? lines[j] : ''
+			if (0 < out.length && isItem(prev) && isItem(next)) {continue}
+		}
+		out.push(lines[i])
 	}
 	return out
 }
@@ -257,6 +286,7 @@ export const lintChangelog = (src: string): { fixed: string; errors: string[] } 
 	const errors: string[] = []
 	let lines = src.split('\n')
 
+	lines = stripLeadingBlanks(lines)
 	lines = ensureTitle(lines, errors)
 	lines = trimTrailing(lines)
 	lines = promoteBoldChangeTypeLabels(lines)
@@ -265,6 +295,7 @@ export const lintChangelog = (src: string): { fixed: string; errors: string[] } 
 	lines = normaliseIndentedSubListItems(lines)
 	lines = normaliseTopLevelBulletMarkers(lines)
 	lines = applySpacingRules(lines)
+	lines = removeBlanksBetweenListItems(lines)
 	lines = finaliseLines(lines)
 
 	return { fixed: lines.join('\n'), errors }

--- a/scripts/linters/lint-readme.ts
+++ b/scripts/linters/lint-readme.ts
@@ -28,8 +28,10 @@
  * Lists
  *   - Items start with "* " (not "- ")
  *   - No trailing whitespace
+ *   - No blank lines between consecutive list items
  *
  * Spacing
+ *   - No leading blank lines before the plugin header
  *   - Exactly 1 blank line before every == section (not the very first)
  *   - Exactly 1 blank line after every == section heading
  *   - Exactly 1 blank line before every = sub-section (not right after == heading)
@@ -94,6 +96,39 @@ const collapseBlankLines = (lines: string[]): string[] => {
 		}
 		out.push(l)
 		prevBlank = blank
+	}
+	return out
+}
+
+/** Remove blank lines before the first content line. */
+const stripLeadingBlanks = (lines: string[]): string[] => {
+	let i = 0
+	while (i < lines.length && '' === lines[i].trim()) {
+		i += 1
+	}
+	return lines.slice(i)
+}
+
+/**
+ * Drop blank lines that sit between two list items. Bullets accumulate stray
+ * blank lines over successive edits; consecutive items should be contiguous.
+ */
+const removeBlanksBetweenListItems = (lines: string[]): string[] => {
+	const isItem = (l: string): boolean => /^\s*[*-] /.test(l)
+	const out: string[] = []
+	for (let i = 0; i < lines.length; i += 1) {
+		if ('' === lines[i].trim()) {
+			let j = i + 1
+			while (j < lines.length && '' === lines[j].trim()) {
+				j += 1
+			}
+			const prev = out[out.length - 1]
+			const next = j < lines.length ? lines[j] : ''
+			if (0 < out.length && isItem(prev) && isItem(next)) {
+				continue
+			}
+		}
+		out.push(lines[i])
 	}
 	return out
 }
@@ -345,6 +380,7 @@ export const lintReadme = (src: string): { fixed: string; errors: string[] } => 
 	const errors: string[] = []
 	let lines = src.split('\n')
 
+	lines = stripLeadingBlanks(lines)
 	lines = normalisePluginHeader(lines, errors)
 	lines = trimTrailing(lines)
 	lines = normaliseHeaderFieldSpacing(lines)
@@ -354,6 +390,7 @@ export const lintReadme = (src: string): { fixed: string; errors: string[] } => 
 	lines = normaliseChangelogChangeTypes(lines)
 	lines = normaliseListItems(lines)
 	lines = applySpacingRules(lines)
+	lines = removeBlanksBetweenListItems(lines)
 	lines = finaliseLines(lines)
 
 	return { fixed: lines.join('\n'), errors }


### PR DESCRIPTION
The `CHANGELOG.md` and `readme.txt` linters (`scripts/linters/lint-changelog.ts`, `scripts/linters/lint-readme.ts`) collapsed *consecutive* blank lines but kept a single blank line sitting **between two list items**. Stray blanks between bullets therefore survived autofix and accumulated across releases.

Both linters gain two passes:

- **No blank lines between consecutive list items** — a blank line is dropped when the line above and the next non-blank line are both list items (`* ` / `- `, including indented sub-items). Blank lines that separate a list from a heading are governed by the existing spacing rules and are untouched.
- **No leading blank lines** before the title / plugin header.

Both linters already run before every release commit via the `.githooks/pre-commit` → lint-staged hook, so generated changelog/readme entries are cleaned automatically — no workflow change needed.

Verified: idempotent on the current committed `CHANGELOG.md` and `src/readme.txt` (no changes); removes stray inter-bullet and leading blanks from messy input; `eslint` clean on both files.
