### PR TITLE
ci: add a label dispatcher and make suites reusable

### DIFF
--- a/.github/actions/release-gate/action.yml
+++ b/.github/actions/release-gate/action.yml
@@ -54,7 +54,7 @@ runs:
             | "\(.status // "missing")|\(.conclusion // "")"'
         }
         pending=false; failed=false
-        for name in "stylelint, eslint, phpcs" "PHPUnit - Test Results Summary" "Playwright - Test Results Summary"; do
+        for name in "lint / stylelint, eslint, phpcs" "phpunit / PHPUnit - Test Results Summary" "playwright / Playwright - Test Results Summary"; do
           s="$(state_of "$name")"; status="${s%%|*}"; conclusion="${s#*|}"
           echo "check '$name' -> status=$status conclusion=$conclusion"
           [ "$status" != "completed" ] && pending=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+# Label dispatcher. This is the single place that decides which suites run.
+# The decision is empirical: it reads the actual event (github.event.action and
+# github.event.label.name), not the ambient label set. So toggling an unrelated
+# label (changelog, build) starts nothing and cancels nothing, and adding two
+# labels at once (two separate labeled events) fans out to only the owning suite.
+#
+# Ownership:
+#   run-tests -> phpunit + playwright
+#   multisite -> the playwright multisite variant
+#   (no label) -> lint runs on every code change
+#
+# The suites are reusable workflows (workflow_call) with no triggering logic of
+# their own, so the decision cannot drift across files.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  push:
+    branches: [core, pro, core-beta, pro-beta]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.gitignore'
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+  statuses: write
+
+# A run that does real work shares the group and supersedes an older run. A stray
+# label event (an unowned label) gets a unique group, so it cancels nothing.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'run-tests' || github.event.label.name == 'multisite') && 'active' || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      lint: ${{ steps.d.outputs.lint }}
+      tests: ${{ steps.d.outputs.tests }}
+      multisite: ${{ steps.d.outputs.multisite }}
+    steps:
+      - id: d
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL: ${{ github.event.label.name }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          is_label=false
+          if [ "$ACTION" = labeled ] || [ "$ACTION" = unlabeled ]; then is_label=true; fi
+          has() { case ",$LABELS," in *,"$1",*) return 0 ;; *) return 1 ;; esac; }
+
+          lint=false; tests=false; multisite=false
+
+          if [ "$EVENT" != pull_request ]; then
+            # push / workflow_dispatch: run the full suite.
+            lint=true; tests=true
+          elif [ "$is_label" = false ]; then
+            # PR opened / reopened / synchronize: lint always; tests if run-tests is present.
+            lint=true
+            has run-tests && tests=true
+          elif [ "$ACTION" = labeled ] && [ "$LABEL" = run-tests ]; then
+            # The exact event that adds run-tests.
+            tests=true
+          fi
+
+          if [ "$tests" = true ] && has multisite; then multisite=true; fi
+
+          {
+            echo "lint=$lint"
+            echo "tests=$tests"
+            echo "multisite=$multisite"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "event=$EVENT action=${ACTION:-none} label=${LABEL:-none} labels=[$LABELS]" >> "$GITHUB_STEP_SUMMARY"
+          echo "decision: lint=$lint tests=$tests multisite=$multisite" >> "$GITHUB_STEP_SUMMARY"
+
+  lint:
+    needs: decide
+    if: needs.decide.outputs.lint == 'true'
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+
+  phpunit:
+    needs: decide
+    if: needs.decide.outputs.tests == 'true'
+    uses: ./.github/workflows/phpunit.yml
+    secrets: inherit
+
+  playwright:
+    needs: decide
+    if: needs.decide.outputs.tests == 'true'
+    uses: ./.github/workflows/playwright.yml
+    with:
+      multisite: ${{ needs.decide.outputs.multisite == 'true' }}
+    secrets: inherit
+
+  # Post the Release Checklist commit status after the suites settle. The action
+  # reads the summary check-runs itself and defers while any are still running, so
+  # it is safe to run with `always()` even when a suite skipped.
+  release-gate:
+    needs: [decide, lint, phpunit, playwright]
+    if: always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout gate action
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/release-gate
+      - name: Release Checklist
+        uses: ./.github/actions/release-gate
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "(Pull Request): CI"
 
 # Label dispatcher. This is the single place that decides which suites run.
 # The decision is empirical: it reads the actual event (github.event.action and

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,25 +1,11 @@
 name: "(Lint): CSS, JS, PHP"
 
+# Reusable suite. Triggering is owned by ci.yml (the label dispatcher).
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-  push:
-    branches:
-      - 'core'
-      - 'pro'
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - 'docs/**'
-  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
-
-concurrency:
-  group: lint-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   lint:
@@ -86,22 +72,3 @@ jobs:
 
       - name: Run PHP CS
         run: npm run lint:php
-
-  # Post the Release Checklist status once lint has concluded. Runs for release
-  # PRs only; defers if the other suites are still running (see the action).
-  release-gate:
-    needs: [lint]
-    if: always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/v')
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout gate action
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions/release-gate
-
-      - name: Release Checklist
-        uses: ./.github/actions/release-gate
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,33 +1,16 @@
 name: "(Test): PHPUnit"
 
+# Reusable suite. Triggering is owned by ci.yml (the label dispatcher).
 on:
-  pull_request:
-    types: [labeled, synchronize, opened, reopened]
-  push:
-    branches:
-      - 'core'
-      - 'pro'
-      - 'core-beta'
-      - 'pro-beta'
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - 'docs/**'
-  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
   pull-requests: read
   actions: read
 
-concurrency:
-  group: phpunit-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   phpunit:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-tests')
     strategy:
       fail-fast: false
       matrix:
@@ -272,23 +255,4 @@ jobs:
       - name: Check overall status
         if: needs.phpunit.result != 'success'
         run: exit 1
-
-  # Post the Release Checklist status once the PHPUnit summary has concluded.
-  # Runs for release PRs only; defers if other required suites are still running.
-  release-gate:
-    needs: [test-result]
-    if: always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/v')
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout gate action
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions/release-gate
-
-      - name: Release Checklist
-        uses: ./.github/actions/release-gate
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,46 +1,34 @@
 name: "(Test): Playwright"
 
+# Reusable suite. Triggering is owned by ci.yml (the label dispatcher).
 on:
-  pull_request:
-    types: [labeled, synchronize, opened, reopened]
-  push:
-    branches:
-      - 'core'
-      - 'pro'
-      - 'core-beta'
-      - 'pro-beta'
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - 'docs/**'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      multisite:
+        required: false
+        type: boolean
+        default: false
+        description: 'Run the multisite variant.'
 
 permissions:
   contents: read
   pull-requests: read
   actions: read
 
-concurrency:
-  group: playwright-${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}-${{ (github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'run-tests') && (github.event.action != 'labeled' || github.event.label.name == 'run-tests' || github.event.label.name == 'multisite'))) && 'tests' || github.run_id }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'run-tests') && (github.event.action != 'labeled' || github.event.label.name == 'run-tests' || github.event.label.name == 'multisite')) }}
-
 jobs:
   playwright-default:
-    if: github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'run-tests') && (github.event.action != 'labeled' || github.event.label.name == 'run-tests' || github.event.label.name == 'multisite'))
     uses: ./.github/workflows/playwright-test.yml
     with:
       test-mode: 'default'
       project-name: 'chromium-db-snippets'
-      multisite: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests') && contains(github.event.pull_request.labels.*.name, 'multisite') }}
+      multisite: ${{ inputs.multisite }}
 
   playwright-file-based-execution:
-    if: github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'run-tests') && (github.event.action != 'labeled' || github.event.label.name == 'run-tests' || github.event.label.name == 'multisite'))
     uses: ./.github/workflows/playwright-test.yml
     with:
       test-mode: 'file-based-execution'
       project-name: 'chromium-file-based-snippets'
-      multisite: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests') && contains(github.event.pull_request.labels.*.name, 'multisite') }}
+      multisite: ${{ inputs.multisite }}
 
   test-result:
     needs: [playwright-default, playwright-file-based-execution]
@@ -333,22 +321,3 @@ jobs:
       - name: Check overall status
         if: ${{ (needs.playwright-default.result != 'success' && needs.playwright-default.result != 'skipped') || (needs.playwright-file-based-execution.result != 'success' && needs.playwright-file-based-execution.result != 'skipped') }}
         run: exit 1
-
-  # Post the Release Checklist status once the Playwright summary has concluded.
-  # Runs for release PRs only; defers if other required suites are still running.
-  release-gate:
-    needs: [test-result]
-    if: always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/v')
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout gate action
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions/release-gate
-
-      - name: Release Checklist
-        uses: ./.github/actions/release-gate
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Route all PR and push CI through one dispatcher, `ci.yml`, that decides which suites run from the **actual event** (`github.event.action` + `github.event.label.name`), not from the ambient label set. This fixes unrelated label toggles re-running or cancelling the test suites, including the two-labels-at-once case (GitHub fires one `labeled` event per label).

## Design

- `ci.yml` (new) triggers on PR `[opened, reopened, synchronize, labeled, unlabeled]`, push to the release branches, and `workflow_dispatch`. A `decide` job computes `lint` / `tests` / `multisite` once and the suite jobs gate on those outputs.
- `lint.yml`, `phpunit.yml`, `playwright.yml` become `workflow_call` reusables with no triggering logic of their own. The decision lives in exactly one place, so it cannot drift between files.
- Concurrency is owned by the dispatcher. A run that does real work shares the group and supersedes older runs; a stray label event gets a unique group and cancels nothing.
- The Release Checklist reporter moves into the dispatcher (one reporter instead of three). `merge-gate.yml` is unchanged and still handles checkbox `edited` re-evaluation.

## Ownership

| Trigger | Runs |
|---|---|
| push / workflow_dispatch | lint + phpunit + playwright |
| PR opened / reopened / synchronize | lint always; tests if `run-tests` present |
| PR labeled `run-tests` | phpunit + playwright |
| PR `multisite` present with tests | playwright multisite variant |
| PR labeled/unlabeled anything else | nothing |

## Action required before this is relied on

1. **Branch protection.** Reusable jobs are check-run prefixed by the caller job id. Required status checks must be renamed:
   - `stylelint, eslint, phpcs` -> `lint / stylelint, eslint, phpcs`
   - `PHPUnit - Test Results Summary` -> `phpunit / PHPUnit - Test Results Summary`
   - `Playwright - Test Results Summary` -> `playwright / Playwright - Test Results Summary`
   The `release-gate` action in this PR already queries the new names.
2. **Verify in CI.** The `decide` logic is unit-tested locally (full truth table) and every workflow parses, but this has not run in live Actions yet. Merge to a scratch branch or open a throwaway PR and toggle labels once before trusting it on releases.

## Not changed

`pull-request.yml` (the `build` label handler) and `merge-gate.yml` keep their own, already-correct event-scoped logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration automation for pull requests, selected branch updates, and manual runs.
  - Centralized linting, PHPUnit, and Playwright checks for more consistent validation.
  - Added optional multisite coverage for Playwright test runs.
  - Improved release-branch verification and corrected status-check detection.
  - Added cancellation of outdated runs to reduce redundant testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->