### PR TITLE
test: point the settings e2e specs at the task-based tabs

### DIFF
--- a/tests/e2e/flat-files.setup.ts
+++ b/tests/e2e/flat-files.setup.ts
@@ -4,7 +4,10 @@ setup('enable flat files', async ({ page }) => {
 	const isMultisite = 'true' === process.env.WP_E2E_MULTISITE_MODE || '1' === process.env.WP_E2E_MULTISITE_MODE
 	const wpAdminbase = isMultisite ? '/wp-admin/network' : '/wp-admin'
   
-	await page.goto(`${wpAdminbase}/admin.php?page=snippets-settings`)
+	// The flat files switch lives on the Running tab; the other tabs are hidden.
+	const settingsUrl = `${wpAdminbase}/admin.php?page=snippets-settings&section=running`
+
+	await page.goto(settingsUrl)
 	await page.waitForSelector('#wpbody-content')
 
 	// Await page.waitForSelector('form')
@@ -29,7 +32,7 @@ setup('enable flat files', async ({ page }) => {
 	])
 
 
-	await page.reload()
+	await page.goto(settingsUrl)
 	await page.waitForSelector('input[name="code_snippets_settings[general][enable_flat_files]"]')
 	await expect(page.locator('input[name="code_snippets_settings[general][enable_flat_files]"]')).toBeChecked()
 })

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const SETTINGS_URL = '/wp-admin/admin.php?page=snippets-settings&section=general'
+const SETTINGS_URL = '/wp-admin/admin.php?page=snippets-settings&section=editing'
 const TABS = '#settings-sections-tabs'
 
 test.describe('Settings tabs', () => {
@@ -8,28 +8,28 @@ test.describe('Settings tabs', () => {
 		await page.goto(SETTINGS_URL)
 
 		const wrap = page.locator('.wrap[data-active-tab]')
-		await expect(wrap).toHaveAttribute('data-active-tab', 'general')
+		await expect(wrap).toHaveAttribute('data-active-tab', 'editing')
 
 		// Mark the document so a full navigation would be detectable below.
 		await page.evaluate(() => {
 			(<Record<string, boolean>> <unknown> window).csSameDocument = true
 		})
 
-		await page.locator(`${TABS} [data-section="editor"]`).click()
+		await page.locator(`${TABS} [data-section="running"]`).click()
 
-		await expect(wrap).toHaveAttribute('data-active-tab', 'editor')
-		await expect(page.locator(`${TABS} [data-section="editor"]`)).toHaveClass(/active-type/)
-		await expect(page).toHaveURL(/section=editor/)
+		await expect(wrap).toHaveAttribute('data-active-tab', 'running')
+		await expect(page.locator(`${TABS} [data-section="running"]`)).toHaveClass(/active-type/)
+		await expect(page).toHaveURL(/section=running/)
 
 		// Redirections after saving must lead back to the selected tab.
-		await expect(page.locator('input[name=_wp_http_referer]')).toHaveValue(/section=editor/)
+		await expect(page.locator('input[name=_wp_http_referer]')).toHaveValue(/section=running/)
 
 		// The swap happens without reloading the page.
 		expect(await page.evaluate(() =>
 			(<Record<string, boolean>> <unknown> window).csSameDocument)).toBe(true)
 
-		await page.locator(`${TABS} [data-section="general"]`).click()
-		await expect(wrap).toHaveAttribute('data-active-tab', 'general')
-		await expect(page.locator(`${TABS} [data-section="general"]`)).toHaveClass(/active-type/)
+		await page.locator(`${TABS} [data-section="editing"]`).click()
+		await expect(wrap).toHaveAttribute('data-active-tab', 'editing')
+		await expect(page.locator(`${TABS} [data-section="editing"]`)).toHaveClass(/active-type/)
 	})
 })


### PR DESCRIPTION
The Playwright suites on core-beta went red after #486 landed: the flat-files setup could no longer see its checkbox, so the whole file-based project did not run, and the settings-tabs spec still expected the old General and Editor sections.

- `tests/e2e/flat-files.setup.ts` opens the Running tab, where the flat files switch now lives, and returns to it after saving.
- `tests/e2e/settings-tabs.spec.ts` switches between the Editing and Running tabs.

No plugin code changes. Both specs pass locally against a wp-env site running core-beta's settings screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for navigating directly to the Running settings tab.
  * Expanded settings-tab checks to cover switching between Running and Editing sections.
  * Updated URL, active-tab, and referrer assertions to match the revised navigation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->