### PR TITLE
fix: follow-ups from review of tonight's core-beta merges

### DIFF
--- a/src/css/import/_upload.scss
+++ b/src/css/import/_upload.scss
@@ -321,15 +321,15 @@
 			text-transform: uppercase;
 			border-radius: 5px;
 
-			@at-root .import-select-card .html-snippet & {
+			@at-root .import-select-card .html-snippet .column-type span {
 				background-color: #cd4510;
 			}
 
-			@at-root .import-select-card .js-snippet & {
+			@at-root .import-select-card .js-snippet .column-type span {
 				background-color: #f7d67a;
 			}
 
-			@at-root .import-select-card .css-snippet & {
+			@at-root .import-select-card .css-snippet .column-type span {
 				background-color: #9b59b6;
 			}
 		}

--- a/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
+++ b/src/js/components/ManageMenu/SnippetsTable/TableColumns.tsx
@@ -31,13 +31,18 @@ const runOnceUrl = (snippet: Snippet, nonce: string): string =>
 		_wpnonce: nonce
 	})
 
-// The rendered link carries the nonce from page load; the click reads the one
-// the Heartbeat has refreshed since, so a page left open still works.
+// The rendered link carries the nonce from page load. Before any navigation
+// starts, whether a click, a middle-click or "open in new tab", the href is
+// rebuilt from the nonce the Heartbeat has refreshed since, so a page left open
+// still works.
 const RunOnceButton: React.FC<ColumnProps> = ({ snippet }) =>
 	<a
 		className="snippet-execution-button"
 		title={__('Run Once', 'code-snippets')}
 		href={runOnceUrl(snippet, window.CODE_SNIPPETS_MANAGE?.runOnceNonce ?? '')}
+		onMouseDown={event => {
+			event.currentTarget.href = runOnceUrl(snippet, getRunOnceNonce())
+		}}
 		onClick={event => {
 			event.preventDefault()
 			window.location.assign(runOnceUrl(snippet, getRunOnceNonce()))

--- a/src/php/Admin/Menus/Edit_Menu.php
+++ b/src/php/Admin/Menus/Edit_Menu.php
@@ -149,6 +149,19 @@ class Edit_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Retrieve the hookname of the edit page.
+	 *
+	 * The page is registered without a parent, so WordPress files it under
+	 * "admin_page_" rather than under the Snippets menu; deriving it from the
+	 * menu slug would name a screen that does not exist.
+	 *
+	 * @return string
+	 */
+	public function get_hookname(): string {
+		return get_plugin_page_hookname( $this->slug, '' );
+	}
+
+	/**
 	 * Retrieve every hookname registered by this menu, including the separate
 	 * "Add New" page, so screen-based checks recognise both editor views.
 	 *
@@ -182,9 +195,8 @@ class Edit_Menu extends Admin_Menu {
 	 * @return void
 	 */
 	protected function ensure_correct_page() {
-		$screen = get_current_screen();
-		$edit_hook = get_plugin_page_hookname( $this->slug, $this->base_slug );
-		$edit_hook .= $screen->in_admin( 'network' ) ? '-network' : '';
+		$screen    = get_current_screen();
+		$edit_hook = $this->get_hookname() . ( $screen->in_admin( 'network' ) ? '-network' : '' );
 
 		// Disallow visiting the edit snippet page without a valid ID.
 		if (

--- a/src/php/snippet-ops.php
+++ b/src/php/snippet-ops.php
@@ -101,6 +101,22 @@ function clean_snippets_cache( string $table_name ) {
  * @return bool Whether the group was flushed.
  */
 function flush_cache_group( string $group ): bool {
+	/**
+	 * Short-circuits flushing a cache group.
+	 *
+	 * Returning a boolean skips the object cache entirely: false makes the
+	 * caller fall back to deleting the known keys one by one, for a cache
+	 * that reports group support it does not really have.
+	 *
+	 * @param bool|null $flushed Whether the group was flushed, or null to let the cache try.
+	 * @param string    $group   Cache group.
+	 */
+	$flushed = apply_filters( 'code_snippets/pre_flush_cache_group', null, $group );
+
+	if ( null !== $flushed ) {
+		return (bool) $flushed;
+	}
+
 	if ( ! function_exists( 'wp_cache_flush_group' ) ||
 	     ! function_exists( 'wp_cache_supports' ) ||
 	     ! wp_cache_supports( 'flush_group' ) ) {
@@ -142,10 +158,12 @@ function flush_versioned_cache_groups( string $previous_version ): void {
  * @return void
  */
 function flush_known_cache_keys(): void {
-	clean_snippets_cache( code_snippets()->db->get_table_name( false ) );
+	// Both tables' keys go, whether or not this is a network: deleting a key
+	// that was never written costs nothing, and it keeps one path to test.
+	$tables = [ code_snippets()->db->get_table_name( false ), code_snippets()->db->get_table_name( true ) ];
 
-	if ( is_multisite() ) {
-		clean_snippets_cache( code_snippets()->db->get_table_name( true ) );
+	foreach ( array_unique( $tables ) as $table ) {
+		clean_snippets_cache( $table );
 	}
 
 	wp_cache_delete( Settings\CACHE_KEY, CACHE_GROUP );
@@ -914,8 +932,13 @@ function get_snippet_by_cloud_id( string $cloud_id, ?bool $multisite = null ): ?
  */
 function normalize_snippet_code( string $code, string $type ): string {
 	// A markdown fence around the whole snippet, as copied from a chat window.
-	$code = preg_replace( '/\A\s*```[a-z]*[ \t]*\R/i', '', $code );
-	$code = preg_replace( '/\R\s*```\s*\z/', '', $code );
+	// The closing fence only goes when an opening one was there: on its own it
+	// is the author's content, as in an HTML snippet ending in backticks.
+	$code = preg_replace( '/\A\s*```[a-z]*[ \t]*\R/i', '', $code, 1, $fenced );
+
+	if ( $fenced ) {
+		$code = preg_replace( '/\R\s*```\s*\z/', '', $code );
+	}
 
 	switch ( $type ) {
 		case 'php':

--- a/tests/unit/Admin/Menus/Edit_Menu_Test.php
+++ b/tests/unit/Admin/Menus/Edit_Menu_Test.php
@@ -21,7 +21,8 @@ class Edit_Menu_Test extends AdminUnitTestCase {
 		parent::set_up();
 
 		set_current_screen( 'toplevel_page_' . code_snippets()->get_menu_slug() );
-		unset( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ] );
+		// The hidden page's registration must be proven by each test, not inherited.
+		unset( $GLOBALS['submenu'][ code_snippets()->get_menu_slug() ], $GLOBALS['submenu'][''] );
 		unset( $_GET['id'] );
 	}
 
@@ -112,5 +113,21 @@ class Edit_Menu_Test extends AdminUnitTestCase {
 
 		$this->assertFalse( has_action( 'admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
 		$this->assertFalse( has_action( 'network_admin_print_footer_scripts', [ $menu, 'disable_menu_link' ] ) );
+	}
+
+	/**
+	 * The hookname the menu reports is the one WordPress registered for the parentless page.
+	 *
+	 * @return void
+	 */
+	public function test_hookname_matches_the_registered_page(): void {
+		$menu = new Edit_Menu();
+		$menu->register();
+
+		$registered = get_plugin_page_hookname( code_snippets()->get_menu_slug( 'edit' ), '' );
+
+		$this->assertSame( $registered, $menu->get_hookname() );
+		$this->assertContains( $registered, $menu->get_hooknames() );
+		$this->assertNotFalse( has_action( 'load-' . $registered, [ $menu, 'load' ] ), 'the load hook is bound to the same name' );
 	}
 }

--- a/tests/unit/Admin/Menus/Manage/Manage_Menu_Run_Once_Test.php
+++ b/tests/unit/Admin/Menus/Manage/Manage_Menu_Run_Once_Test.php
@@ -101,7 +101,10 @@ class Manage_Menu_Run_Once_Test extends UnitTestCase {
 		$snippet->code   = $code;
 		$snippet->active = false;
 
-		return save_snippet( $snippet );
+		$saved = save_snippet( $snippet );
+		$this->assertNotNull( $saved, 'the single-use snippet must save before the test can run it' );
+
+		return $saved;
 	}
 
 	/**
@@ -186,5 +189,21 @@ class Manage_Menu_Run_Once_Test extends UnitTestCase {
 
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
 		$this->assertArrayNotHasKey( 'code_snippets_run_once_nonce', $menu->refresh_run_once_nonce( [] ) );
+	}
+
+	/**
+	 * A user without the capability is refused even with a nonce of their own.
+	 *
+	 * @return void
+	 */
+	public function test_capability_is_required_even_with_a_valid_nonce(): void {
+		$snippet = $this->single_use( 'update_option( "run_once_ran", "yes" );' );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$own_nonce = wp_create_nonce( Manage_Menu::RUN_ONCE_NONCE );
+
+		$this->assertNull( $this->run_once_request( $snippet->id, $own_nonce ) );
+		$this->assertFalse( (bool) get_snippet( $snippet->id )->active );
+		$this->assertFalse( get_option( 'run_once_ran' ) );
 	}
 }

--- a/tests/unit/Core/Versioned_Cache_Test.php
+++ b/tests/unit/Core/Versioned_Cache_Test.php
@@ -115,11 +115,14 @@ class Versioned_Cache_Test extends UnitTestCase {
 	 * @return void
 	 */
 	public function test_known_keys_are_deleted_without_a_group_flush(): void {
-		$table = code_snippets()->db->get_table_name( false );
-		$keys  = [
+		$table   = code_snippets()->db->get_table_name( false );
+		$network = code_snippets()->db->get_table_name( true );
+		$keys    = [
 			"all_snippets_$table",
 			"all_snippet_tags_$table",
 			'active_snippets_global_single-use_front-end_' . $table,
+			"all_snippets_$network",
+			"all_snippet_tags_$network",
 			\Code_Snippets\Settings\CACHE_KEY,
 		];
 
@@ -146,5 +149,27 @@ class Versioned_Cache_Test extends UnitTestCase {
 		flush_versioned_cache_groups( '' );
 
 		$this->assertFalse( wp_cache_get( "all_snippets_$table", CACHE_GROUP ) );
+	}
+
+	/**
+	 * When the cache cannot flush a group, the full flush still removes every known key.
+	 *
+	 * @return void
+	 */
+	public function test_versioned_flush_falls_back_to_known_keys(): void {
+		$table = code_snippets()->db->get_table_name( false );
+		$keys  = [ "all_snippets_$table", "all_snippet_tags_$table", \Code_Snippets\Settings\CACHE_KEY ];
+
+		foreach ( $keys as $key ) {
+			wp_cache_set( $key, 'stale', CACHE_GROUP );
+		}
+
+		add_filter( 'code_snippets/pre_flush_cache_group', '__return_false' );
+		flush_versioned_cache_groups( '' );
+		remove_filter( 'code_snippets/pre_flush_cache_group', '__return_false' );
+
+		foreach ( $keys as $key ) {
+			$this->assertFalse( wp_cache_get( $key, CACHE_GROUP ), $key );
+		}
 	}
 }

--- a/tests/unit/Settings/Settings_Layout_Test.php
+++ b/tests/unit/Settings/Settings_Layout_Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for the task-based settings layout.
+ *
+ * @package Code_Snippets
+ */
+
+namespace Code_Snippets\Settings;
+
+use Code_Snippets\Admin\Menus\Settings_Menu;
+use Code_Snippets\UnitTestCase;
+use ReflectionClass;
+
+/**
+ * Tabs only show fields that exist and apply; headings and labels render once and escaped.
+ *
+ * @group settings
+ */
+class Settings_Layout_Test extends UnitTestCase {
+
+	/**
+	 * Remove what a test registered.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		global $wp_settings_fields, $wp_settings_sections;
+
+		unset( $wp_settings_fields[ Settings_Menu::SETTINGS_PAGE ]['layout-test'], $wp_settings_sections[ Settings_Menu::SETTINGS_PAGE ] );
+		unset( $_REQUEST['section'] );
+		remove_all_filters( 'code_snippets_settings_tab_contents' );
+		remove_all_filters( 'code_snippets_settings_tabs' );
+		parent::tear_down();
+	}
+
+	/**
+	 * A field the definitions do not know, and one whose condition is not met, are left out.
+	 *
+	 * @return void
+	 */
+	public function test_undefined_and_hidden_fields_are_left_out(): void {
+		add_filter(
+			'code_snippets_settings_tab_contents',
+			static function ( array $contents ): array {
+				$contents['interface'][] = [ 'general', 'no_such_field' ];
+				return $contents;
+			}
+		);
+
+		$settings = Settings_Fields::get_default_values();
+
+		$settings['general']['enable_admin_bar'] = false;
+		$hidden                                  = Settings_Layout::get_visible_fields( 'interface', $settings );
+
+		$settings['general']['enable_admin_bar'] = true;
+		$shown                                   = Settings_Layout::get_visible_fields( 'interface', $settings );
+
+		$this->assertNotContains( [ 'general', 'no_such_field' ], $shown, 'a field with no definition is skipped' );
+		$this->assertNotContains( [ 'general', 'admin_bar_snippet_limit' ], $hidden, 'a field whose condition is not met is skipped' );
+		$this->assertContains( [ 'general', 'admin_bar_snippet_limit' ], $shown );
+		$this->assertContains( [ 'general', 'enable_admin_bar' ], $hidden, 'the field the condition depends on is always there' );
+		$this->assertSame( [], Settings_Layout::get_visible_fields( 'no-such-tab', $settings ) );
+	}
+
+	/**
+	 * A tab with nothing to show is not offered.
+	 *
+	 * @return void
+	 */
+	public function test_tabs_with_nothing_to_show_are_unavailable(): void {
+		add_filter(
+			'code_snippets_settings_tabs',
+			static function ( array $tabs ): array {
+				$tabs['empty'] = 'Empty';
+				return $tabs;
+			}
+		);
+
+		$available = Settings_Layout::get_available_tabs();
+
+		$this->assertArrayHasKey( 'editing', $available );
+		$this->assertArrayNotHasKey( 'empty', $available );
+	}
+
+	/**
+	 * A group heading renders once for its group, escaped, and a labelable field gets a real label.
+	 *
+	 * @return void
+	 */
+	public function test_group_headings_render_once_and_escaped(): void {
+		add_settings_section( 'layout-test', 'Layout test', '__return_empty_string', Settings_Menu::SETTINGS_PAGE );
+		add_settings_field( 'first', 'First', '__return_null', Settings_Menu::SETTINGS_PAGE, 'layout-test', [ 'group_heading' => 'Group <b>one</b>' ] );
+		add_settings_field(
+			'second',
+			'Second',
+			'__return_null',
+			Settings_Menu::SETTINGS_PAGE,
+			'layout-test',
+			[
+				'group_heading' => 'Group <b>one</b>',
+				'label_for'     => 'field-second',
+			]
+		);
+		add_settings_field( 'third', 'Third', '__return_null', Settings_Menu::SETTINGS_PAGE, 'layout-test', [ 'group_heading' => 'Group two' ] );
+
+		ob_start();
+		do_settings_fields_with_headings( Settings_Menu::SETTINGS_PAGE, 'layout-test' );
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( 1, substr_count( $html, 'Group &lt;b&gt;one&lt;/b&gt;' ), 'the heading is drawn once and escaped' );
+		$this->assertStringNotContainsString( '<b>one</b>', $html );
+		$this->assertStringContainsString( 'Group two', $html );
+		$this->assertStringContainsString( '<label for="field-second">Second</label>', $html );
+		$this->assertStringContainsString( '<th scope="row">First</th>', $html );
+	}
+
+	/**
+	 * The current section is the requested one when it exists, else the default, else the first.
+	 *
+	 * @return void
+	 */
+	public function test_current_section_falls_back_sensibly(): void {
+		global $wp_settings_sections;
+
+		// Only the registered sections are read, so the menu's dependencies are not needed.
+		$menu = ( new ReflectionClass( Settings_Menu::class ) )->newInstanceWithoutConstructor();
+
+		$this->assertSame( 'anything', $menu->get_current_section( 'anything' ), 'with no sections the default is returned as given' );
+
+		$wp_settings_sections[ Settings_Menu::SETTINGS_PAGE ] = [ // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture, removed in tear_down.
+			'editing' => [ 'id' => 'editing' ],
+			'running' => [ 'id' => 'running' ],
+		];
+
+		$this->assertSame( 'running', $menu->get_current_section( 'running' ) );
+		$this->assertSame( 'editing', $menu->get_current_section( 'no-such-section' ), 'an unknown default falls back to the first tab' );
+
+		$_REQUEST['section'] = 'running';
+		$this->assertSame( 'running', $menu->get_current_section() );
+
+		$_REQUEST['section'] = '<script>bogus</script>';
+		$this->assertSame( 'editing', $menu->get_current_section(), 'an invalid request value falls back to the first tab' );
+	}
+}

--- a/tests/unit/Snippets/Normalize_Snippet_Code_Test.php
+++ b/tests/unit/Snippets/Normalize_Snippet_Code_Test.php
@@ -78,6 +78,8 @@ class Normalize_Snippet_Code_Test extends UnitTestCase {
 			'script tag inside php'    => [ 'php', "echo '<script>x()</script>';" ],
 			'style tag mid-css'        => [ 'css', ".a { content: '<style>'; }" ],
 			'backticks inside code'    => [ 'js', 'const sql = `SELECT 1`;' ],
+			'orphan closing fence'     => [ 'html', "<p>Example</p>\n```" ],
+			'closing fence in css'     => [ 'css', ".a {}\n```" ],
 			'html type is left alone'  => [ 'html', "<style>\n.a {}\n</style>" ],
 		];
 	}


### PR DESCRIPTION
Follow-ups from review of what landed on core-beta this evening (#519, #466, #486, #489).

- Import screen: the type badge selectors doubled the card and table path, so the per-type colours never matched a row.
- Run Once: the link rebuilds its href from the Heartbeat-refreshed nonce on mousedown, so a middle-click or "open in new tab" on a page left open no longer sends an expired nonce.
- Edit page: registered without a parent, its hookname is `admin_page_…`; the menu now reports that name, so screen matching and the invalid-edit redirect work again.
- Pasted code: a closing code fence is only removed when an opening one was, so an HTML snippet that ends in backticks keeps them.
- Cache flush: both snippet tables' keys are cleared regardless of network mode, and a `code_snippets/pre_flush_cache_group` filter lets a cache that misreports group support fall back to per-key deletion; the fallback is now exercised through the full flush.
- Tests: the settings layout (undefined and conditional fields, empty tabs, escaped group headings drawn once, label output, current-section fallbacks), Run Once capability with a valid nonce, the fixture save, and the hidden submenu reset between tests.

Full PHPUnit suite green locally (239 tests, 25 pre-existing skips); phpcs, eslint and stylelint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running single-use snippets, including preventing unauthorized execution.
  * Fixed navigation and hook handling for hidden and parentless admin pages.
  * Improved cache cleanup across single-site and multisite configurations.
  * Corrected Markdown fence handling in HTML and CSS snippets.
  * Improved settings layout rendering by hiding unavailable fields and empty sections.
  * Corrected snippet table styling selectors for consistent syntax coloring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->