### PR TITLE
fix: colour the tags help text where the field actually lives

### DIFF
--- a/src/css/edit/_gpt.scss
+++ b/src/css/edit/_gpt.scss
@@ -109,3 +109,10 @@
 		justify-content: flex-end;
 	}
 }
+
+// The tags field sits in the lower form area, not the sidebar. Its help text
+// takes the component's own grey, 4.05:1 on this surface, from an injected
+// single-class rule; two classes outrank it and the muted token clears 4.5:1.
+.snippet-tags-container .components-form-token-field__help {
+	color: var(--cs-color-text-muted);
+}

--- a/src/css/edit/_sidebar.scss
+++ b/src/css/edit/_sidebar.scss
@@ -179,12 +179,6 @@
 
 	.components-form-token-field {
 		inline-size: 100%;
-
-		// The component's own grey is 4.05:1 on the sidebar surface; the muted
-		// text token clears the 4.5:1 floor.
-		.components-form-token-field__help {
-			color: var(--cs-color-text-muted);
-		}
 	}
 
 	.generate-button {


### PR DESCRIPTION
Follow-up to #522: the help-text rule was nested under the sidebar block, but the tags field renders in the lower form area, so it never matched and the text stayed at 4.05:1. The rule now targets the tags container directly, which also outranks the component's injected single-class colour. Verified with axe on a wp-env site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated snippet tag form help text to use the standard muted text color.
  - Improved visual consistency for token-field help text in the snippet editor sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->