### PR TITLE
ci: take the workflow input through the environment in both Playwright steps

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -241,27 +241,33 @@ jobs:
           WP_E2E_WP_CONTAINER: ${{ job.services.wordpress.id }}
           WP_E2E_MULTISITE_MODE: ${{ inputs.multisite }}
           PLAYWRIGHT_PROJECTS: ${{ inputs.project-name }}
+          PLAYWRIGHT_SUFFIX: ${{ inputs.project-name }}${{ inputs.multisite && '-multisite' || '' }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p test-results/ci
-          suffix="${{ inputs.project-name }}${{ inputs.multisite && '-multisite' || '' }}"
+          suffix="$PLAYWRIGHT_SUFFIX"
           : > "test-results/ci/playwright-${suffix}.log"
           # One --project flag per name, so several projects can be listed in the input.
           # The names arrive through the environment rather than being pasted into
-          # the script, so no input value is ever interpreted as shell.
+          # the script, and are split into an array without pathname expansion, so
+          # no input value is ever interpreted as shell or as a glob.
+          read -ra projects <<< "$PLAYWRIGHT_PROJECTS"
           project_args=()
-          for project in $PLAYWRIGHT_PROJECTS; do
+          for project in "${projects[@]}"; do
             project_args+=(--project "$project")
           done
           npm run test:playwright -- "${project_args[@]}" 2>&1 | tee -a "test-results/ci/playwright-${suffix}.log"
 
       - name: Normalize Playwright report filenames
         if: always()
+        env:
+          PLAYWRIGHT_SUFFIX: ${{ inputs.project-name }}${{ inputs.multisite && '-multisite' || '' }}
+        shell: bash
         run: |
           set -euo pipefail
           mkdir -p test-results/ci
-          suffix="${{ inputs.project-name }}${{ inputs.multisite && '-multisite' || '' }}"
+          suffix="$PLAYWRIGHT_SUFFIX"
 
           if [ -f test-results/results.xml ]; then
             mv test-results/results.xml "test-results/ci/results-${suffix}.xml"


### PR DESCRIPTION
Follow-up from review of #526. Both steps that build the log and report suffix now read it from a step environment variable, so the workflow input is no longer interpolated into any script; the project names are read into an array before iterating, so nothing is subject to pathname expansion. The suffix text is unchanged, so downstream steps that look for the log by name are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated browser test execution when running multiple projects.
  * Prevented project names and report suffixes from being misinterpreted by the shell, producing more reliable test results and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->