### PR TITLE
ci: reject an empty project-name input before running Playwright

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -252,6 +252,7 @@ jobs:
           # The names arrive through the environment rather than being pasted into
           # the script, and are split into an array without pathname expansion, so
           # no input value is ever interpreted as shell or as a glob.
+          [[ -n "${PLAYWRIGHT_PROJECTS// /}" ]] || { echo "The project-name input is empty; nothing to run." >&2; exit 1; }
           read -ra projects <<< "$PLAYWRIGHT_PROJECTS"
           project_args=()
           for project in "${projects[@]}"; do


### PR DESCRIPTION
Follow-up from review of #527. The input is declared required and both callers pass literal names, but the step now also refuses a blank value with a clear message rather than running the whole suite with no project selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playwright test runs now fail early with a clear error when the project name is missing or contains only whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->