### PR TITLE
fix: quote the php binary path and raise the blueprint focus contrast

### DIFF
--- a/src/css/manage/blueprints/_form-layout.scss
+++ b/src/css/manage/blueprints/_form-layout.scss
@@ -51,7 +51,10 @@ $border-color: #c3c4c7;
 		&:hover,
 		&:focus-visible {
 			background: var(--cs-color-accent-subtle);
-			color: var(--cs-color-accent);
+
+			// The lighter accent reaches only 3.8:1 on this background; the
+			// hover shade clears AA for normal text.
+			color: var(--cs-color-accent-hover);
 			outline: none;
 		}
 

--- a/tests/unit/Flat_Files/Handlers/Functions_Snippet_Handler_Test.php
+++ b/tests/unit/Flat_Files/Handlers/Functions_Snippet_Handler_Test.php
@@ -52,7 +52,7 @@ class Functions_Snippet_Handler_Test extends UnitTestCase {
 		$output = [];
 		$status = 0;
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- A subprocess is the only way to detect a compile error without killing the test run.
-		exec( escapeshellcmd( PHP_BINARY ) . ' -l ' . escapeshellarg( $file ) . ' 2>&1', $output, $status );
+		exec( escapeshellarg( PHP_BINARY ) . ' -l ' . escapeshellarg( $file ) . ' 2>&1', $output, $status );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removing a temp file created by this test.
 		unlink( $file );
 


### PR DESCRIPTION
## Summary

Two independent fixes, one commit each.

**Quote the PHP binary path when linting generated flat files.** `Functions_Snippet_Handler_Test` shells out to `php -l` to confirm a generated flat file compiles, building the command with `escapeshellcmd( PHP_BINARY )`. That function escapes shell metacharacters but does not quote whitespace, so any PHP binary installed under a path containing a space is split into separate words by the shell. On such a machine all seven guard tests fail with `sh: /Users/…/Library/Application: No such file or directory` rather than a lint result. `escapeshellarg()` quotes the whole path. CI is unaffected either way because its runner path has no spaces; the failure only appears locally, for example with Laravel Herd on macOS, where it looks like a genuine test failure.

**Raise the blueprint form focus contrast.** The blueprint form's hover and `:focus-visible` state puts `--cs-color-accent` (`#2271b1`) on `--cs-color-accent-subtle` (`#c9e1f5`), which measures 3.83:1 — below the 4.5:1 WCAG AA threshold for normal text. `--cs-color-accent-hover` (`#0a4b78`) on the same background measures 6.80:1. `AGENTS.md` requires accessible focus behaviour.

## Verification

- `npm run test:php` — 261 tests, 0 failures. On a PHP binary path containing a space the same suite reported 7 failures before this change, all in `Functions_Snippet_Handler_Test`; that file's 8 tests now pass.
- `npm run build` — compiles successfully
- `npm run lint:php`, `lint:styles` — clean
- Contrast ratios computed against the WCAG relative luminance formula.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar item hover and keyboard-focus colors for better contrast and visibility.
  - Improved handling of PHP executable paths during validation, reducing issues when paths contain special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->