### PR TITLE
fix: give the blueprint form items a visible keyboard focus indicator

### DIFF
--- a/src/css/manage/blueprints/_form-layout.scss
+++ b/src/css/manage/blueprints/_form-layout.scss
@@ -55,7 +55,14 @@ $border-color: #c3c4c7;
 			// The lighter accent reaches only 3.8:1 on this background; the
 			// hover shade clears AA for normal text.
 			color: var(--cs-color-accent-hover);
-			outline: none;
+		}
+
+		// The fill alone separates the focused item from its neighbours by
+		// 1.26:1, so keyboard focus needs a border of its own. Drawn inside the
+		// item, which sits flush against the ones above and below it.
+		&:focus-visible {
+			outline: 2px solid var(--cs-color-accent-hover);
+			outline-offset: -2px;
 		}
 
 		&.is-active {


### PR DESCRIPTION
## Summary

Follow-up to #530, which merged before this commit was pushed. The review thread on that PR was answered and resolved on the basis of this change, but the merge did not include it, so the issue it describes is still present on `core-beta`.

The blueprint form's list items removed the browser focus indicator with `outline: none` and relied on the background change alone to show focus. The unfocused fill `#f6f7f7` and the focused fill `#c9e1f5` differ by 1.26:1, well under the 3:1 minimum for a focus indicator, so keyboard focus was effectively invisible. `outline: none` also applied to `:hover`, where it did nothing.

Hover and focus are now separated: hover keeps the fill and text colour, and `:focus-visible` additionally draws a `2px` outline in `--cs-color-accent-hover`. That colour measures 6.80:1 against the focused fill and 8.54:1 against the surrounding list, both clearing the 3:1 minimum. `outline-offset: -2px` draws it inside the item, which sits flush against its neighbours.

## Verification

- `npm run build` — compiles successfully
- `npm run lint:styles` — clean
- Contrast ratios computed against the WCAG relative luminance formula


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus visibility for sidebar items with a clear inset accent outline.
  * Preserved existing hover and focus-visible styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->