### PR TITLE
fix: keep the cloud table's select-all honest when nothing can be downloaded

### DIFF
--- a/src/js/components/ManageMenu/CommunityCloud/CloudSnippetsTable.tsx
+++ b/src/js/components/ManageMenu/CommunityCloud/CloudSnippetsTable.tsx
@@ -64,21 +64,39 @@ interface TableHeadingCheckboxProps {
 	setSelectedIds: Dispatch<SetStateAction<Set<CloudSnippetSchema['id']>>>
 }
 
+/**
+ * Selects every snippet on the page that can be downloaded. With nothing
+ * downloadable the box is disabled and unticked: "all of nothing" must not
+ * read as a selection.
+ */
 const TableHeadingCheckbox: React.FC<TableHeadingCheckboxProps> = ({ availableIds, selectedIds, setSelectedIds }) =>
 	<td className="column-cb check-column">
 		<input
 			id="cb-select-all-cloud-snippets"
 			type="checkbox"
-			checked={availableIds.every(snippetId => selectedIds.has(snippetId))}
+			checked={0 < availableIds.length && availableIds.every(snippetId => selectedIds.has(snippetId))}
+			disabled={0 === availableIds.length}
+			title={0 === availableIds.length ? __('Nothing on this page can be downloaded.', 'code-snippets') : undefined}
 			onChange={event =>
 				setSelectedIds(previous =>
 					new Set(event.target.checked
 						? [...previous, ...availableIds]
 						: [...previous].filter(snippetId => !availableIds.includes(snippetId)))
 				)}
-			aria-label={__('Select all snippets', 'code-snippets')}
+			aria-label={__('Select all downloadable snippets', 'code-snippets')}
 		/>
 	</td>
+
+/** Why a snippet cannot be selected for download, or undefined when it can. */
+const unavailableReason = (snippet: CloudSnippetSchema): string | undefined => {
+	if (snippet.local_id) {
+		return __('Already in your library.', 'code-snippets')
+	}
+
+	return isCloudSnippetDownloadable(snippet)
+		? undefined
+		: __('Requires Code Snippets Pro.', 'code-snippets')
+}
 
 interface TableRowCheckboxProps {
 	snippet: CloudSnippetSchema
@@ -86,24 +104,37 @@ interface TableRowCheckboxProps {
 	setSelected: Dispatch<SetStateAction<Set<CloudSnippetSchema['id']>>>
 }
 
-const TableRowCheckbox: React.FC<TableRowCheckboxProps> = ({ snippet, selected, setSelected }) =>
-	<th scope="row" className="check-column">
-		{isCloudSnippetDownloadable(snippet) && (
+/**
+ * Every row shows a box, so the column reads as one control: a snippet that
+ * cannot be downloaded gets a disabled box that says why.
+ */
+const TableRowCheckbox: React.FC<TableRowCheckboxProps> = ({ snippet, selected, setSelected }) => {
+	const reason = unavailableReason(snippet)
+
+	return (
+		<th scope="row" className="check-column">
 			<input
 				id={`cb-select-${snippet.id}`}
 				type="checkbox"
 				name="checked[]"
-				checked={selected.has(snippet.id)}
-				// translators: %s: snippet name.
-				aria-label={sprintf(__('Select %s', 'code-snippets'), snippet.name)}
+				checked={!reason && selected.has(snippet.id)}
+				disabled={!!reason}
+				title={reason}
+				aria-label={reason
+					// translators: 1: snippet name, 2: why it cannot be selected.
+					? sprintf(__('%1$s cannot be selected: %2$s', 'code-snippets'), snippet.name, reason)
+					// translators: %s: snippet name.
+					: sprintf(__('Select %s', 'code-snippets'), snippet.name)}
 				onChange={event =>
 					setSelected(previous =>
 						new Set(event.target.checked
 							? [...previous, snippet.id]
 							: [...previous].filter(snippetId => snippetId !== snippet.id))
 					)}
-			/>)}
-	</th>
+			/>
+		</th>
+	)
+}
 
 export interface CloudSnippetsTableProps {
 	snippets: CloudSnippetSchema[]

--- a/tests/e2e/cloud-download-eligibility.spec.ts
+++ b/tests/e2e/cloud-download-eligibility.spec.ts
@@ -87,11 +87,15 @@ test.describe('Cloud bulk download eligibility', () => {
 
 		const table = page.locator('.cloud-snippets-table')
 		await expect(table.getByRole('checkbox', { name: 'Select Eligible Alpha' })).toBeVisible()
-		await expect(table.getByRole('checkbox', { name: 'Select Linked Beta' })).toHaveCount(0)
-		await expect(table.getByRole('checkbox', { name: 'Select Pro Gamma' })).toHaveCount(0)
+		// Rows that cannot be downloaded keep a box, disabled, that says why.
+		await expect(table.getByRole('checkbox', { name: 'Linked Beta cannot be selected: Already in your library.' })).toBeDisabled()
+		await expect(table.getByRole('checkbox', { name: 'Pro Gamma cannot be selected: Requires Code Snippets Pro.' })).toBeDisabled()
 
-		await table.getByRole('checkbox', { name: 'Select all snippets' }).check()
+		const selectAll = table.getByRole('checkbox', { name: 'Select all downloadable snippets' })
+		await expect(selectAll).not.toBeChecked()
+		await selectAll.check()
 		await expect(table.getByRole('checkbox', { name: 'Select Eligible Alpha' })).toBeChecked()
+		await expect(table.getByRole('checkbox', { name: 'Linked Beta cannot be selected: Already in your library.' })).not.toBeChecked()
 
 		await applyBulkDownload(page)
 		await expect.poll(() => state.downloads).toEqual([ELIGIBLE.id])
@@ -123,11 +127,32 @@ test.describe('Cloud bulk download eligibility', () => {
 
 		const table = page.locator('.cloud-snippets-table')
 		await expect(table.getByRole('checkbox', { name: 'Select Pro Gamma' })).toBeVisible()
-		await expect(table.getByRole('checkbox', { name: 'Select Linked Beta' })).toHaveCount(0)
+		await expect(table.getByRole('checkbox', { name: 'Linked Beta cannot be selected: Already in your library.' })).toBeDisabled()
 
-		await table.getByRole('checkbox', { name: 'Select all snippets' }).check()
+		await table.getByRole('checkbox', { name: 'Select all downloadable snippets' }).check()
 		await applyBulkDownload(page)
 		await expect.poll(() => [...state.downloads].sort((a, b) => a - b)).toEqual([ELIGIBLE.id, PRO_LOCKED.id])
+	})
+
+	test('a page with nothing downloadable offers no selection at all', async ({ page }) => {
+		const state: CloudRoutesState = {
+			snippets: [
+				cloudSnippet({ id: 201, name: 'Owned One', local_id: 11 }),
+				cloudSnippet({ id: 202, name: 'Owned Two', local_id: 12 })
+			],
+			downloads: []
+		}
+		await forceLicenseState(page, true)
+		await routeCloudSnippets(page, state)
+		await openCommunityCloud(page, 'table')
+
+		const table = page.locator('.cloud-snippets-table')
+		const selectAll = table.getByRole('checkbox', { name: 'Select all downloadable snippets' })
+		// "All of nothing" must not read as a selection: the header box is unticked and disabled.
+		await expect(selectAll).toBeDisabled()
+		await expect(selectAll).not.toBeChecked()
+		await expect(table.getByRole('checkbox', { name: 'Owned One cannot be selected: Already in your library.' })).toBeDisabled()
+		await expect(table.getByRole('checkbox', { name: 'Owned Two cannot be selected: Already in your library.' })).toBeDisabled()
 	})
 
 	test('selections hidden by a new search are not downloaded', async ({ page }) => {

--- a/tests/e2e/code-snippets-community-featured.spec.ts
+++ b/tests/e2e/code-snippets-community-featured.spec.ts
@@ -262,7 +262,7 @@ test.describe('Community Cloud Featured Snippets', () => {
 		const table = page.locator('.cloud-snippets-table')
 		await expect(table).toBeVisible({ timeout: TIMEOUTS.DEFAULT })
 
-		const headerCheckbox = table.locator('thead').getByRole('checkbox', { name: 'Select all snippets' })
+		const headerCheckbox = table.locator('thead').getByRole('checkbox', { name: 'Select all downloadable snippets' })
 		const rowCheckbox = table.locator('tbody').getByRole('checkbox', { name: 'Select Mock Cloud Snippet' })
 
 		// The table owns the only select-all control; the toolbar checkbox is


### PR DESCRIPTION
On the Community Cloud table, the header checkbox showed ticked while doing nothing, and the rows had no checkboxes, whenever every snippet on the page was already downloaded (or Pro-only on an unlicensed site). Row boxes were only rendered for downloadable snippets, and the header computed "all of the downloadable ones are selected" over an empty list, which is true.

**Fix**

- The header box ticks only when there is at least one downloadable snippet and all of them are selected; with none it is disabled and unticked, with a title saying nothing on the page can be downloaded.
- Every row now shows a box. A snippet that cannot be selected gets a disabled one whose title and label say why: already in your library, or requires Code Snippets Pro.

**Verified** on the dev site with the featured endpoint stubbed: three already-downloaded snippets give a disabled, unticked header and three disabled rows with reasons; a mixed page gives an enabled header that selects only the downloadable row.

Based on the current core-beta. Follows to pro-beta with the next sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud snippet selection to include only downloadable snippets.
  * Disabled and clarified the selection control when no snippets are available.
  * Added clear explanations for snippets that are already present or require Pro access.
  * Ensured unavailable snippets remain visibly disabled while preserving valid selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->