### PR TITLE
fix: adjust snippet card meta styles

### DIFF
--- a/src/css/manage/_cloud-community-cards.scss
+++ b/src/css/manage/_cloud-community-cards.scss
@@ -62,6 +62,8 @@
 		gap: 16px;
 		font-size: 14px;
 		line-height: 1.5;
+		border-block-end: 1px solid var(--cs-color-border-subtle);
+		padding-block-end: 16px;
 
 		.cloud-snippet-tags {
 			color: var(--cs-color-accent);
@@ -83,8 +85,6 @@
 		font-size: 14px;
 		line-height: 1.5;
 		color: var(--cs-color-text-muted);
-		border-block-start: 1px solid var(--cs-color-border-subtle);
-		padding-block-start: 16px;
 	}
 
 	.cloud-snippet-author {

--- a/src/css/manage/_snippets-table.scss
+++ b/src/css/manage/_snippets-table.scss
@@ -170,6 +170,8 @@
 		gap: 16px;
 		font-size: 14px;
 		line-height: 1.5;
+		border-block-end: 1px solid var(--cs-color-border-subtle);
+		padding-block-end: 16px;
 
 		.snippet-card-tags-label {
 			color: var(--cs-color-text-muted);
@@ -198,8 +200,6 @@
 		font-size: 14px;
 		line-height: 1.5;
 		color: var(--cs-color-text-muted);
-		border-block-start: 1px solid var(--cs-color-border-subtle);
-		padding-block-start: 16px;
 	}
 
 	// Align the selection checkbox with the taller card header row.


### PR DESCRIPTION
When the snippet has no description, the card view is missing a seperator.

Before:

<img width="1337" height="705" alt="Screenshot 2026-09-05 at 18 13 05" src="https://github.com/user-attachments/assets/f2b553d0-5e80-4f05-b181-9c3fb88a8e07" />

After:

<img width="1341" height="704" alt="Screenshot 2026-09-05 at 18 13 46" src="https://github.com/user-attachments/assets/143c684b-db3a-4cc5-b01f-a735497de1fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated snippet card styling so metadata sections display the visual separator and spacing.
  - Removed the separator and top spacing previously shown above descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->