### PR TITLE
fix: consistent screen-meta slot in all the pages

### DIFF
--- a/src/css/common/_demo.scss
+++ b/src/css/common/_demo.scss
@@ -27,7 +27,6 @@ $modal-gutter-inset: 40px;
 // title rather than being pushed to the far end of the row.
 .demo-page-header {
 	justify-content: flex-start;
-	margin-block: 32px 24px;
 
 	h1 {
 		display: flex;

--- a/src/css/common/_page-header.scss
+++ b/src/css/common/_page-header.scss
@@ -9,14 +9,14 @@
 	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: 16px 24px;
-	margin-block: 8px 16px;
+	margin-block: 0.5rem 16px;
 
 	h1,
 	h2 {
 		margin: 0;
 		padding: 0;
 		font-size: 26px;
-		font-weight: 510;
+		font-weight: 500;
 		line-height: 1.25;
 	}
 

--- a/src/css/common/_subnav.scss
+++ b/src/css/common/_subnav.scss
@@ -208,26 +208,6 @@
 	}
 }
 
-// Slot that adopts the WordPress Screen Options / Help tabs so they appear
-// directly below the snippet-type nav instead of above the page content.
-.snippets-screen-meta-slot {
-	#screen-meta-links {
-		float: none;
-		display: flex;
-		justify-content: flex-end;
-		margin: 0;
-		border-color: var(--cs-color-border-subtle);
-
-		.show-settings {
-			border-color: var(--cs-color-border-subtle);
-		}
-	}
-
-	#screen-meta {
-		margin: 0;
-	}
-}
-
 // Item count shown after a subnav tab's label, using the label colour at reduced opacity.
 .snippet-type-nav .subnav-count {
 	font-size: 14px;

--- a/src/css/common/_toolbar.scss
+++ b/src/css/common/_toolbar.scss
@@ -48,12 +48,6 @@
 		}
 	}
 
-	h1 {
-		font-size: 18px;
-		font-weight: 700;
-		line-height: 1.5;
-	}
-
 	ul {
 		display: flex;
 		gap: 22px;
@@ -336,5 +330,25 @@
 @media (width <= 640px) {
 	.code-snippets-toolbar-upper .logo div {
 		display: none;
+	}
+}
+
+// Slot that adopts the WordPress Screen Options / Help tabs so they appear
+// directly below the toolbar instead of above the page content.
+.snippets-screen-meta-slot {
+	#screen-meta-links {
+		float: none;
+		display: flex;
+		justify-content: flex-end;
+		margin: 0;
+		border-color: var(--cs-color-border-subtle);
+
+		.show-settings {
+			border-color: var(--cs-color-border-subtle);
+		}
+	}
+
+	#screen-meta {
+		margin: 0;
 	}
 }

--- a/src/css/edit.scss
+++ b/src/css/edit.scss
@@ -31,6 +31,10 @@
 	cursor: pointer;
 }
 
+#edit-snippet-container {
+	margin-block-start: 0;
+}
+
 .snippet-description-container {
 	label {
 		font-size: 1.16em;
@@ -93,11 +97,11 @@
 }
 
 .wrap > h1:first-of-type {
-	font-size: 1.5rem;
-	font-weight: 400;
+	font-size: 24px;
+	font-weight: 500;
 	line-height: 1.3;
 	padding: 0;
-	margin-block: 50px 1rem;
+	margin-block: 0.5rem 1rem;
 }
 
 .snippet-name-wrapper {

--- a/src/css/edit/_form.scss
+++ b/src/css/edit/_form.scss
@@ -87,7 +87,6 @@
 }
 
 .snippet-form {
-	margin-block-start: 10px;
 	display: grid;
 	gap: var(--cs-sidebar-gap);
 	grid-template-columns: 1fr var(--cs-sidebar-width);

--- a/src/css/insights.scss
+++ b/src/css/insights.scss
@@ -2,17 +2,18 @@
 @use 'common/toolbar';
 @use 'common/wp-admin';
 
-.code-snippets-insights {
-	margin-block: 50px;
-	margin-inline: auto;
-	color: var(--cs-color-text);
+#code-snippets-insights-container {
+	margin-block-start: 0;
+}
 
+.snippets-page-header {
 	h1 {
-		padding: 0;
-		margin: 0;
-		font-size: 32px;
-		font-weight: 510;
+		font-size: 26px;
+		font-weight: 500;
 		line-height: 1.25;
+		color: var(--cs-color-text);
+		padding: 0;
+		margin-block: 0.5rem 1rem;
 	}
 }
 
@@ -20,7 +21,6 @@
 	display: grid;
 	gap: 16px;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
-	margin-block: 16px;
 }
 
 .insights-chart-card {

--- a/src/css/welcome.scss
+++ b/src/css/welcome.scss
@@ -3,14 +3,18 @@
 @use 'common/toolbar';
 @use 'common/wp-admin';
 
+#code-snippets-welcome-container {
+	margin-block-start: 0;
+}
+
 .code-snippets-welcome {
 	h1 {
-		font-size: 32px;
-		font-weight: 510;
+		font-size: 26px;
+		font-weight: 500;
 		line-height: 1.25;
 		color: var(--cs-color-text);
 		padding: 0;
-		margin-block: 50px 1rem;
+		margin-block: 0.5rem 1rem;
 	}
 }
 

--- a/src/js/components/EditMenu/EditMenu.tsx
+++ b/src/js/components/EditMenu/EditMenu.tsx
@@ -1,9 +1,4 @@
 import React from 'react'
-import { ScreenMetaSlot } from '../common/ScreenMetaSlot'
 import { SnippetForm } from './SnippetForm'
 
-export const EditMenu = () =>
-	<>
-		<ScreenMetaSlot />
-		<SnippetForm />
-	</>
+export const EditMenu = () => <SnippetForm />

--- a/src/js/components/EditMenu/EditMenu.tsx
+++ b/src/js/components/EditMenu/EditMenu.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
+import { ScreenMetaSlot } from '../common/ScreenMetaSlot'
 import { SnippetForm } from './SnippetForm'
 
 export const EditMenu = () =>
-	<SnippetForm />
+	<>
+		<ScreenMetaSlot />
+		<SnippetForm />
+	</>

--- a/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
+++ b/src/js/components/EditMenu/SnippetForm/SnippetForm.tsx
@@ -9,6 +9,7 @@ import { handleUnknownError } from '../../../utils/errors'
 import { createSnippetObject, getSnippetType, isCondition, validateSnippet } from '../../../utils/snippets/snippets'
 import { buildUrl } from '../../../utils/urls'
 import { ConfirmDialog } from '../../common/ConfirmDialog'
+import { ScreenMetaSlot } from '../../common/ScreenMetaSlot'
 import { Toolbar } from '../../common/Toolbar'
 import { UpsellBanner } from '../../common/UpsellBanner'
 import { UpsellDialog } from '../../common/UpsellDialog'
@@ -234,6 +235,7 @@ export const SnippetForm: React.FC = () =>
 					initialSnippet={() => createSnippetObject(window.CODE_SNIPPETS_EDIT?.snippet)}
 				>
 					<Toolbar />
+					<ScreenMetaSlot />
 					<EditFormWrap />
 				</WithSnippetFormContext>
 			</WithSnippetsListContext>

--- a/src/js/components/InsightsMenu/InsightsMenu.tsx
+++ b/src/js/components/InsightsMenu/InsightsMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { WithRestAPIContext } from '../../hooks/useRestAPI'
+import { ScreenMetaSlot } from '../common/ScreenMetaSlot'
 import { Toolbar } from '../common/Toolbar'
 import { InsightsDashboard } from './InsightsDashboard'
 
@@ -9,6 +10,7 @@ export const InsightsMenu: React.FC = () => {
 	return (
 		<>
 			<Toolbar />
+			<ScreenMetaSlot />
 			{summary && (
 				<div className="code-snippets-insights">
 					<WithRestAPIContext>

--- a/src/js/components/ManageMenu/AiAgentDemo/AiAgentDemo.tsx
+++ b/src/js/components/ManageMenu/AiAgentDemo/AiAgentDemo.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { __ } from '@wordpress/i18n'
 import { WithRestAPIContext } from '../../../hooks/useRestAPI'
+import { ScreenMetaSlot } from '../../common/ScreenMetaSlot'
 import { DemoCallout } from '../../common/demo/DemoCallout'
 import { DemoPageHeader } from '../../common/demo/DemoPageHeader'
 import { DemoSpotlight } from '../../common/demo/DemoSpotlight'
@@ -83,82 +84,85 @@ const AiAgentDemoPage: React.FC = () => {
 	const promptSent = hasReached(stage, 'prompt-sent')
 
 	return (
-		<div className="ai-agent ai-agent-demo">
-			<DemoPageHeader
-				title={__('AI Agent', 'code-snippets')}
-				description={__('A guided walkthrough of the Pro AI Agent. Press play and watch it plan, build, and refine a snippet on your site.', 'code-snippets')}
-				hasStarted={hasStarted}
-				isFinished={isFinished}
-				onPlay={play}
-				onSkip={skip}
-				onReplay={replay}
-			/>
+		<>
+			<ScreenMetaSlot />
+			<div className="ai-agent ai-agent-demo">
+				<DemoPageHeader
+					title={__('AI Agent', 'code-snippets')}
+					description={__('A guided walkthrough of the Pro AI Agent. Press play and watch it plan, build, and refine a snippet on your site.', 'code-snippets')}
+					hasStarted={hasStarted}
+					isFinished={isFinished}
+					onPlay={play}
+					onSkip={skip}
+					onReplay={replay}
+				/>
 
-			<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
+				<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
 
-			<DemoCallout callout={getCallout(stage)} />
+				<DemoCallout callout={getCallout(stage)} />
 
-			<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
+				<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
 
-			<div className="ai-agent-layout">
-				<div className="ai-agent-layout__main">
-					{!promptSent && <div className="ai-agent-empty">
-						<p className="ai-agent-empty__eyebrow">{__('Start with these prompts', 'code-snippets')}</p>
+				<div className="ai-agent-layout">
+					<div className="ai-agent-layout__main">
+						{!promptSent && <div className="ai-agent-empty">
+							<p className="ai-agent-empty__eyebrow">{__('Start with these prompts', 'code-snippets')}</p>
 
-						<div className="ai-agent-empty__chips">
-							{DEMO_EXAMPLES.map(example =>
-								<button key={example} type="button" className="ai-agent-empty__chip" disabled>
-									{example}
-								</button>)}
-						</div>
-					</div>}
+							<div className="ai-agent-empty__chips">
+								{DEMO_EXAMPLES.map(example =>
+									<button key={example} type="button" className="ai-agent-empty__chip" disabled>
+										{example}
+									</button>)}
+							</div>
+						</div>}
 
-					<div className="ai-agent-thread">
-						{hasReached(stage, 'prompt-sent') && <DemoMessage speaker="user">{DEMO_PROMPT}</DemoMessage>}
+						<div className="ai-agent-thread">
+							{hasReached(stage, 'prompt-sent') && <DemoMessage speaker="user">{DEMO_PROMPT}</DemoMessage>}
 
-						{'planning' === stage && <>
-							<DemoTransit label={__('Sending your prompt to Code Snippets Cloud.', 'code-snippets')} />
-							<DemoTyping label={__('Planning your snippets…', 'code-snippets')} />
-						</>}
+							{'planning' === stage && <>
+								<DemoTransit label={__('Sending your prompt to Code Snippets Cloud.', 'code-snippets')} />
+								<DemoTyping label={__('Planning your snippets…', 'code-snippets')} />
+							</>}
 
-						{hasReached(stage, 'plan-ready') && !hasReached(stage, 'building') &&
+							{hasReached(stage, 'plan-ready') && !hasReached(stage, 'building') &&
 							<DemoPlanCard accepted={'plan-accepted' === stage} />}
 
-						{'building' === stage && <>
-							<DemoTransit label={__('Building the snippets in Code Snippets Cloud.', 'code-snippets')} />
-							<DemoTyping label={__('Building the code…', 'code-snippets')} />
-						</>}
+							{'building' === stage && <>
+								<DemoTransit label={__('Building the snippets in Code Snippets Cloud.', 'code-snippets')} />
+								<DemoTyping label={__('Building the code…', 'code-snippets')} />
+							</>}
 
-						{hasReached(stage, 'result-ready') && <DemoResultCard
-							stage={stage}
-							snippets={snippets}
-							typedRefinement={typedRefinement}
-						/>}
+							{hasReached(stage, 'result-ready') && <DemoResultCard
+								stage={stage}
+								snippets={snippets}
+								typedRefinement={typedRefinement}
+							/>}
 
-						{'applying' === stage && <DemoTyping label={__('Applying your changes…', 'code-snippets')} />}
+							{'applying' === stage && <DemoTyping label={__('Applying your changes…', 'code-snippets')} />}
 
-						{hasReached(stage, 'saved') && <DemoMessage speaker="assistant">{DEMO_REFINEMENT_REPLY}</DemoMessage>}
+							{hasReached(stage, 'saved') && <DemoMessage speaker="assistant">{DEMO_REFINEMENT_REPLY}</DemoMessage>}
+						</div>
+
+						<DemoPromptBox
+							value={hasReached(stage, 'planning') ? '' : typedPrompt}
+							typing={'typing-prompt' === stage}
+							pressed={'prompt-sent' === stage}
+							disabled={promptSent}
+							submitLabel={__('Send', 'code-snippets')}
+							placeholder={__('Describe what you want to build…', 'code-snippets')}
+						/>
 					</div>
 
-					<DemoPromptBox
-						value={hasReached(stage, 'planning') ? '' : typedPrompt}
-						typing={'typing-prompt' === stage}
-						pressed={'prompt-sent' === stage}
-						disabled={promptSent}
-						submitLabel={__('Send', 'code-snippets')}
-						placeholder={__('Describe what you want to build…', 'code-snippets')}
-					/>
+					<div className="ai-agent-layout__sidebar">
+						<DemoSidebar stage={stage} />
+					</div>
 				</div>
 
-				<div className="ai-agent-layout__sidebar">
-					<DemoSidebar stage={stage} />
-				</div>
+				{isFinished && <div ref={upsellRef} className="ai-agent-demo__closing">
+					<AiAgentDemoUpsell onReplay={replay} />
+				</div>}
 			</div>
-
-			{isFinished && <div ref={upsellRef} className="ai-agent-demo__closing">
-				<AiAgentDemoUpsell onReplay={replay} />
-			</div>}
-		</div>
+		</>
 	)
 }
 

--- a/src/js/components/ManageMenu/BlueprintsDemo/BlueprintsDemo.tsx
+++ b/src/js/components/ManageMenu/BlueprintsDemo/BlueprintsDemo.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { __ } from '@wordpress/i18n'
 import { WithRestAPIContext } from '../../../hooks/useRestAPI'
+import { ScreenMetaSlot } from '../../common/ScreenMetaSlot'
 import { DemoPageHeader } from '../../common/demo/DemoPageHeader'
 import { DemoSpotlight } from '../../common/demo/DemoSpotlight'
 import { DemoCallout } from '../../common/demo/DemoCallout'
@@ -85,48 +86,51 @@ const BlueprintsDemoPage: React.FC = () => {
 	}, [reducedMotion, stage])
 
 	return (
-		<div className="blueprints-demo">
-			<DemoPageHeader
-				title={__('Blueprints', 'code-snippets')}
-				description={__('A guided walkthrough of Pro Blueprints. Press play and watch a shortcode blueprint fill itself in and generate a snippet.', 'code-snippets')}
-				hasStarted={hasStarted}
-				isFinished={isFinished}
-				onPlay={play}
-				onSkip={skip}
-				onReplay={replay}
-			/>
+		<>
+			<ScreenMetaSlot />
+			<div className="blueprints-demo">
+				<DemoPageHeader
+					title={__('Blueprints', 'code-snippets')}
+					description={__('A guided walkthrough of Pro Blueprints. Press play and watch a shortcode blueprint fill itself in and generate a snippet.', 'code-snippets')}
+					hasStarted={hasStarted}
+					isFinished={isFinished}
+					onPlay={play}
+					onSkip={skip}
+					onReplay={replay}
+				/>
 
-			<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
+				<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
 
-			<DemoCallout callout={getCallout(stage)} />
+				<DemoCallout callout={getCallout(stage)} />
 
-			<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
+				<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
 
-			<div className="blueprint-detail">
-				<BlueprintHeader />
+				<div className="blueprint-detail">
+					<BlueprintHeader />
 
-				<div className="blueprint-form-layout">
-					<BlueprintSidebar
-						activeSection={activeSection}
-						browsable={sectionsBrowsable}
-						generating={'generating' === stage}
-						onSelect={selectSection}
-					/>
+					<div className="blueprint-form-layout">
+						<BlueprintSidebar
+							activeSection={activeSection}
+							browsable={sectionsBrowsable}
+							generating={'generating' === stage}
+							onSelect={selectSection}
+						/>
 
-					<BlueprintFormPanel section={getSection(activeSection)} isFading={isFading} />
+						<BlueprintFormPanel section={getSection(activeSection)} isFading={isFading} />
+					</div>
 				</div>
+
+				{showGenerated && <GeneratedNotice ref={generatedRef} />}
+
+				{isFinished && <DemoUpsell
+					title={__('That was a demo — Blueprints build the code for you', 'code-snippets')}
+					onReplay={replay}
+				>
+					<p>{__('The whole walkthrough was scripted and ran inside this plugin. No code was generated and nothing was saved.', 'code-snippets')}</p>
+					<p>{__('Code Snippets Pro ships blueprints for shortcodes, post types, taxonomies, settings pages, and more — fill in the form and it writes the snippet for you.', 'code-snippets')}</p>
+				</DemoUpsell>}
 			</div>
-
-			{showGenerated && <GeneratedNotice ref={generatedRef} />}
-
-			{isFinished && <DemoUpsell
-				title={__('That was a demo — Blueprints build the code for you', 'code-snippets')}
-				onReplay={replay}
-			>
-				<p>{__('The whole walkthrough was scripted and ran inside this plugin. No code was generated and nothing was saved.', 'code-snippets')}</p>
-				<p>{__('Code Snippets Pro ships blueprints for shortcodes, post types, taxonomies, settings pages, and more — fill in the form and it writes the snippet for you.', 'code-snippets')}</p>
-			</DemoUpsell>}
-		</div>
+		</>
 	)
 }
 

--- a/src/js/components/ManageMenu/CloudLibraryDemo/CloudLibraryDemo.tsx
+++ b/src/js/components/ManageMenu/CloudLibraryDemo/CloudLibraryDemo.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { __ } from '@wordpress/i18n'
 import { getSnippetType } from '../../../utils/snippets/snippets'
 import { ListTable } from '../../common/ListTable'
+import { ScreenMetaSlot } from '../../common/ScreenMetaSlot'
 import { DemoCallout } from '../../common/demo/DemoCallout'
 import { DemoPageHeader } from '../../common/demo/DemoPageHeader'
 import { DemoSpotlight } from '../../common/demo/DemoSpotlight'
@@ -59,50 +60,53 @@ export const CloudLibraryDemo: React.FC = () => {
 	}, [isFinished, reducedMotion])
 
 	return (
-		<div className="cloud-library-demo">
-			<DemoPageHeader
-				title={__('Cloud Library', 'code-snippets')}
-				description={__('A guided walkthrough of the Pro Cloud Library. Press play and watch a snippet move from your cloud onto this site.', 'code-snippets')}
-				hasStarted={hasStarted}
-				isFinished={isFinished}
-				onPlay={play}
-				onSkip={skip}
-				onReplay={replay}
-			/>
-
-			<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
-
-			<DemoCallout callout={getCallout(stage)} />
-
-			<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
-
-			<div className="cloud-library-snippets snippets-list-view">
-				<ListTable
-					fixed
-					striped
-					items={snippets}
-					columns={cloudLibraryDemoColumns({ stage, onPreview: setPreview })}
-					getKey={snippet => snippet.id}
-					rowClassName={snippet => FEATURED_SNIPPET_ID === snippet.id ? 'demo-featured-row' : ''}
-				/>
-			</div>
-
-			{isFinished && <div ref={upsellRef} className="cloud-library-demo__closing">
-				<DemoUpsell
-					title={__('That was a demo — your cloud travels with you', 'code-snippets')}
+		<>
+			<ScreenMetaSlot />
+			<div className="cloud-library-demo">
+				<DemoPageHeader
+					title={__('Cloud Library', 'code-snippets')}
+					description={__('A guided walkthrough of the Pro Cloud Library. Press play and watch a snippet move from your cloud onto this site.', 'code-snippets')}
+					hasStarted={hasStarted}
+					isFinished={isFinished}
+					onPlay={play}
+					onSkip={skip}
 					onReplay={replay}
-				>
-					<p>{__('The whole walkthrough was scripted and ran inside this plugin. These snippets are examples, and nothing was downloaded or saved.', 'code-snippets')}</p>
-					<p>{__('With Code Snippets Pro your Cloud Library is available on every site you connect, so a snippet written once can be reused everywhere and kept in sync.', 'code-snippets')}</p>
-				</DemoUpsell>
-			</div>}
+				/>
 
-			{preview && <PreviewModal
-				title={preview.name}
-				code={preview.code}
-				type={getSnippetType(preview)}
-				onRequestClose={() => setPreview(undefined)}
-			/>}
-		</div>
+				<div className="screen-reader-text" aria-live="polite">{STAGE_ANNOUNCEMENTS[stage]}</div>
+
+				<DemoCallout callout={getCallout(stage)} />
+
+				<DemoSpotlight {...STAGE_SPOTLIGHTS[stage]} />
+
+				<div className="cloud-library-snippets snippets-list-view">
+					<ListTable
+						fixed
+						striped
+						items={snippets}
+						columns={cloudLibraryDemoColumns({ stage, onPreview: setPreview })}
+						getKey={snippet => snippet.id}
+						rowClassName={snippet => FEATURED_SNIPPET_ID === snippet.id ? 'demo-featured-row' : ''}
+					/>
+				</div>
+
+				{isFinished && <div ref={upsellRef} className="cloud-library-demo__closing">
+					<DemoUpsell
+						title={__('That was a demo — your cloud travels with you', 'code-snippets')}
+						onReplay={replay}
+					>
+						<p>{__('The whole walkthrough was scripted and ran inside this plugin. These snippets are examples, and nothing was downloaded or saved.', 'code-snippets')}</p>
+						<p>{__('With Code Snippets Pro your Cloud Library is available on every site you connect, so a snippet written once can be reused everywhere and kept in sync.', 'code-snippets')}</p>
+					</DemoUpsell>
+				</div>}
+
+				{preview && <PreviewModal
+					title={preview.name}
+					code={preview.code}
+					type={getSnippetType(preview)}
+					onRequestClose={() => setPreview(undefined)}
+				/>}
+			</div>
+		</>
 	)
 }

--- a/src/js/components/WelcomeMenu/WelcomeMenu.tsx
+++ b/src/js/components/WelcomeMenu/WelcomeMenu.tsx
@@ -1,5 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n'
 import React, { useState } from 'react'
+import { ScreenMetaSlot } from '../common/ScreenMetaSlot'
 import { Toolbar } from '../common/Toolbar'
 import { Changelog } from './Changelog'
 import type { ImageLinkSchema } from '../../types/schema/WelcomeSchema'
@@ -100,6 +101,7 @@ const Articles: React.FC<ArticlesProps> = ({ articles }) =>
 export const WelcomeMenu = () =>
 	<>
 		<Toolbar />
+		<ScreenMetaSlot />
 		<div className="code-snippets-welcome">
 			<h1>{__('Resources and Updates', 'code-snippets')}</h1>
 

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -15,7 +15,10 @@ test.describe('Screen meta slot', () => {
 		test(`renders a slot on the ${screen.name} screen`, async ({ page }) => {
 			await page.goto(screen.url)
 
-			await expect(page.locator('#snippets-screen-meta-slot')).toHaveCount(1)
+			const screenMetaSlot = page.locator('#snippets-screen-meta-slot')
+
+			await expect(screenMetaSlot.locator('#screen-meta')).toHaveCount(1)
+			await expect(screenMetaSlot.locator('#screen-meta-links')).toHaveCount(1)
 		})
 	}
 })

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { URLS } from './helpers/constants'
+
+const SCREENS = [
+	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
+	{ name: 'Cloud Library', url: '/wp-admin/admin.php?page=snippets&subpage=cloud-library' },
+	{ name: 'Blueprints', url: '/wp-admin/admin.php?page=snippets&subpage=blueprints' },
+	{ name: 'AI Agent', url: '/wp-admin/admin.php?page=snippets&subpage=ai-agent' },
+	{ name: 'Insights', url: '/wp-admin/admin.php?page=code-snippets-insights' },
+	{ name: 'Welcome', url: URLS.WELCOME_SCREEN_ADMIN }
+]
+
+test.describe('Screen meta slot', () => {
+	for (const screen of SCREENS) {
+		test(`renders a slot on the ${screen.name} screen`, async ({ page }) => {
+			await page.goto(screen.url)
+
+			await expect(page.locator('#snippets-screen-meta-slot')).toHaveCount(1)
+		})
+	}
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized the placement of Screen Options and Help controls across snippet editing, insights, welcome, and demo screens.
  * Refined page headers, headings, spacing, margins, and typography for a more consistent admin experience.
  * Improved alignment and layout of toolbar metadata and page content.
* **Bug Fixes**
  * Corrected spacing around edit forms, insights dashboards, welcome content, and demo pages.
  * Updated screen metadata positioning to appear beneath the primary toolbar consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->