### PR TITLE
fix: use the error token for the AI Agent error and warning colours

### DIFF
--- a/src/css/manage/_ai-agent.scss
+++ b/src/css/manage/_ai-agent.scss
@@ -172,7 +172,7 @@
 	padding-inline: 10px;
 
 	&:hover {
-		color: var(#b32d2e);
+		color: var(--cs-color-error);
 	}
 }
 
@@ -407,15 +407,15 @@
 }
 
 .ai-agent-result__status.is-error {
-	color: var(#b32d2e);
+	color: var(--cs-color-error);
 	font-size: 12px;
 }
 
 .ai-agent-result__status.is-deleted {
-	color: var(#b32d2e);
+	color: var(--cs-color-error);
 	font-weight: 600;
 	text-decoration: underline;
-	text-decoration-color: var(#b32d2e);
+	text-decoration-color: var(--cs-color-error);
 }
 
 .ai-agent-result__status.is-checking {
@@ -747,7 +747,7 @@
 	overflow: hidden;
 
 	&.is-warning .ai-agent-quota__fill {
-		background: var(#b32d2e);
+		background: var(--cs-color-error);
 	}
 }
 
@@ -757,6 +757,6 @@
 	color: var(--cs-color-text-secondary);
 
 	&.is-warning {
-		color: var(#b32d2e);
+		color: var(--cs-color-error);
 	}
 }


### PR DESCRIPTION
## Summary

`src/css/manage/_ai-agent.scss` contains six declarations written as `var(#b32d2e)`. A custom property name must begin with `--`, so these are invalid and the browser discards the declaration at parse time. The AI Agent's error and warning colours currently fall back to the inherited text colour.

The affected declarations are the destructive history control on hover and focus, the error and deleted result statuses and the deleted status underline, the quota bar fill in its warning state, and the message limit value in its warning state.

Each is replaced with `var(--cs-color-error)`, already defined in `src/css/common/_theme.scss` and used for the same purpose elsewhere, such as `.license-status-expired` in `src/css/settings.scss`.

## Cause

The substitution arrived with the migration from hardcoded colours to CSS variables. The stylesheet previously declared `$warning: #b32d2e` and referenced it as `color: $warning`. The replacement wrapped the literal value in `var()` rather than substituting the token, so `$warning` became `#b32d2e` inside `var()`.

Sass compiles `var(#b32d2e)` without complaint and stylelint does not reject it, so the build and the linters pass regardless.

## Verification

- `grep -rn 'var(#' src/css/` returns no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected error-state colors for history deletion, results, quota warnings, and message-limit warnings.
  - Updated these states to use the appropriate design token for consistent visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->