### PR TITLE
fix: set the active flag on the insights chart link test snippet

### DIFF
--- a/tests/e2e/code-snippets-insights.spec.ts
+++ b/tests/e2e/code-snippets-insights.spec.ts
@@ -125,6 +125,7 @@ test.describe('Insights screen', () => {
 	test('links chart entries to their filtered snippet lists', async ({ page, baseURL }) => {
 		await SnippetsTestHelper.createSnippetViaCli({
 			name: 'Insights Tagged Snippet',
+			active: true,
 			tags: ['sample']
 		})
 


### PR DESCRIPTION
## Summary

`tests/e2e/code-snippets-insights.spec.ts:126` calls `SnippetsTestHelper.createSnippetViaCli()` without `active`, which `CreateSnippetCliOptions` declares as required. `npx tsc --noEmit` reports:

```
tests/e2e/code-snippets-insights.spec.ts(126,48): error TS2345: Argument of type '{ name: string; tags: string[]; }' is not assignable to parameter of type 'CreateSnippetCliOptions'.
```

Every other call in the file passes the flag, including the two in the neighbouring tags chart test, so this sets `active: true` to match.

The spec still runs today because Playwright transpiles without type checking, and the linters do not type check either, so nothing in CI reports it.

## Verification

- `npx tsc --noEmit` no longer reports an error for this file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the chart-link end-to-end test to use an active tagged code snippet fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->