### PR TITLE
fix: update manage table view logic to include explicit snippets subpage

### DIFF
--- a/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
+++ b/src/php/Admin/Menus/Manage/Manage_Menu_Screen_Options.php
@@ -107,7 +107,7 @@ class Manage_Menu_Screen_Options {
 	 * @return bool
 	 */
 	public function is_manage_table_view(): bool {
-		return ! $this->get_current_subpage();
+		return in_array( $this->get_current_subpage(), [ '', 'snippets' ], true );
 	}
 
 	/**

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -3,6 +3,7 @@ import { URLS } from './helpers/constants'
 
 const SCREENS = [
 	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
+	{ name: 'Manage Snippets', url: `${URLS.SNIPPETS_ADMIN}&subpage=snippets` },
 	{ name: 'Cloud Library', url: '/wp-admin/admin.php?page=snippets&subpage=cloud-library' },
 	{ name: 'Blueprints', url: '/wp-admin/admin.php?page=snippets&subpage=blueprints' },
 	{ name: 'AI Agent', url: '/wp-admin/admin.php?page=snippets&subpage=ai-agent' },

--- a/tests/unit/Admin/Menus/Manage/Manage_Menu_Screen_Options_Test.php
+++ b/tests/unit/Admin/Menus/Manage/Manage_Menu_Screen_Options_Test.php
@@ -75,6 +75,19 @@ class Manage_Menu_Screen_Options_Test extends AdminUnitTestCase {
 	}
 
 	/**
+	 * The explicit snippets subpage renders the Manage table.
+	 *
+	 * @return void
+	 */
+	public function test_explicit_snippets_subpage_is_the_manage_table_view(): void {
+		$_REQUEST['subpage'] = 'snippets';
+		$options = new Manage_Menu_Screen_Options();
+
+		$this->assertTrue( $options->is_manage_table_view() );
+		$this->assertFalse( $options->is_upsell_view() );
+	}
+
+	/**
 	 * The AI Agent demo is detected as its own view, and keeps the upsell
 	 * treatment that strips Screen Options and Help tabs from the page.
 	 *


### PR DESCRIPTION
The `<ScreenMetaSlot />` is not displayed consistently.

It's not displayed in: `admin.php?page=snippets&subpage=snippets`

But it is displayed in: `admin.php?page=snippets`

This PR fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Manage Snippets screen now correctly displays the snippets table when accessed through its explicit subpage.
  - Other subpages continue to use their existing specialized or upgrade-related views.

- **Tests**
  - Added coverage for the Manage Snippets screen in screen metadata end-to-end tests.
  - Added validation to ensure the explicit Snippets subpage is not incorrectly shown as an upgrade view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->