### PR TITLE
feat: add condition usage chart to the insights page

### DIFF
--- a/src/js/components/InsightsMenu/InsightsDashboard.tsx
+++ b/src/js/components/InsightsMenu/InsightsDashboard.tsx
@@ -11,6 +11,7 @@ import type { SnippetCodeScope, SnippetType } from '../../types/Snippet'
 export const DEFAULT_INSIGHTS_CHART_VIEWS: InsightsChartViews = window.CODE_SNIPPETS?.insightsChartViews ?? {
 	type: 'bar',
 	activation: 'pie',
+	conditions: 'pie',
 	location: 'bar'
 }
 
@@ -25,6 +26,11 @@ export const INSIGHTS_TYPE_COLORS: Readonly<Record<SnippetType, string>> = {
 export const INSIGHTS_ACTIVATION_COLORS: Readonly<Record<string, string>> = {
 	active: '#118822',
 	inactive: '#cd4510'
+}
+
+export const INSIGHTS_CONDITION_COLORS: Readonly<Record<string, string>> = {
+	with: '#22826f',
+	without: '#9b59b6'
 }
 
 export const INSIGHTS_LOCATION_COLORS: Readonly<Record<SnippetCodeScope, string>> = {
@@ -81,6 +87,16 @@ const ActivationStatusChart: React.FC<ConfigurableChartProps> = ({ summary, view
 			}
 		}}
 		colors={INSIGHTS_ACTIVATION_COLORS}
+		view={view}
+		setView={setView}
+	/>
+
+const ConditionUsageChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
+	<InsightsChart
+		chart="conditions"
+		title={__('Condition usage', 'code-snippets')}
+		entries={summary.conditionCounts}
+		colors={INSIGHTS_CONDITION_COLORS}
 		view={view}
 		setView={setView}
 	/>
@@ -158,6 +174,12 @@ export const InsightsDashboard: React.FC<InsightsDashboardProps> = ({ summary })
 				summary={summary}
 				view={chartViews.activation}
 				setView={view => updateChartView('activation', view)}
+			/>
+
+			<ConditionUsageChart
+				summary={summary}
+				view={chartViews.conditions}
+				setView={view => updateChartView('conditions', view)}
 			/>
 
 			<LocationChart

--- a/src/js/types/Insights.ts
+++ b/src/js/types/Insights.ts
@@ -2,7 +2,7 @@ import type { SnippetScope, SnippetType } from './Snippet'
 
 export type InsightsChartKey = 'total' | InsightsConfigurableChartKey | 'tags'
 
-export type InsightsConfigurableChartKey = 'type' | 'activation' | 'location'
+export type InsightsConfigurableChartKey = 'type' | 'activation' | 'conditions' | 'location'
 
 export type InsightsChartView = 'pie' | 'bar'
 
@@ -18,6 +18,7 @@ export interface InsightsSummary {
 	readonly active: number | string
 	readonly inactive: number | string
 	readonly typeCounts: Readonly<Record<SnippetType, InsightsChartEntry>>
+	readonly conditionCounts: Readonly<Record<string, InsightsChartEntry>>
 	readonly locationCounts: Readonly<Record<SnippetScope, number>>
 	readonly tagCounts: Readonly<Record<string, InsightsChartEntry>>
 }

--- a/src/php/Admin/Menus/Insights/Insights_Summary.php
+++ b/src/php/Admin/Menus/Insights/Insights_Summary.php
@@ -45,6 +45,7 @@ final class Insights_Summary {
 	 *     active: int,
 	 *     inactive: int,
 	 *     typeCounts: array<string, array{label: string, count: int}>,
+	 *     conditionCounts: array<string, array{label: string, count: int}>,
 	 *     locationCounts: array<string, int>,
 	 *     tagCounts: array<string, array{label: string, count: int}>
 	 * }
@@ -62,6 +63,7 @@ final class Insights_Summary {
 	 *     active: int,
 	 *     inactive: int,
 	 *     typeCounts: array<string, array{label: string, count: int}>,
+	 *     conditionCounts: array<string, array{label: string, count: int}>,
 	 *     locationCounts: array<string, int>,
 	 *     tagCounts: array<string, array{label: string, count: int}>
 	 * }
@@ -84,6 +86,7 @@ final class Insights_Summary {
 		}
 
 		$type_counts = array_fill_keys( self::TYPE_ORDER, 0 );
+		$condition_counts = array_fill_keys( [ 'with', 'without' ], 0 );
 		$location_counts = array_fill_keys( self::LOCATION_ORDER, 0 );
 		$tag_counts = [];
 		$active = 0;
@@ -94,6 +97,8 @@ final class Insights_Summary {
 			if ( isset( $type_counts[ $type ] ) ) {
 				++$type_counts[ $type ];
 			}
+
+			++$condition_counts[ $snippet->condition_id ? 'with' : 'without' ];
 
 			if ( 'condition' === $snippet->scope ) {
 				$is_active = isset( $active_condition_ids[ $snippet->id ] );
@@ -120,6 +125,7 @@ final class Insights_Summary {
 			'active'         => $active,
 			'inactive'       => count( $snippets ) - $active,
 			'typeCounts'     => $this->create_chart_entries( $type_counts, $this->get_type_labels() ),
+			'conditionCounts' => $this->create_chart_entries( $condition_counts, $this->get_condition_usage_labels() ),
 			'locationCounts' => array_filter( $location_counts ),
 			'tagCounts'      => $this->create_tag_chart_entries( $tag_counts ),
 		];
@@ -194,6 +200,18 @@ final class Insights_Summary {
 			'css'  => __( 'CSS', 'code-snippets' ),
 			'js'   => __( 'JS', 'code-snippets' ),
 			'cond' => __( 'Conditions', 'code-snippets' ),
+		];
+	}
+
+	/**
+	 * Retrieve display labels for condition usage.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_condition_usage_labels(): array {
+		return [
+			'with'    => __( 'Uses conditions', 'code-snippets' ),
+			'without' => __( 'Does not use conditions', 'code-snippets' ),
 		];
 	}
 }

--- a/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
+++ b/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
@@ -32,7 +32,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 	/**
 	 * Insights charts with independently configurable views.
 	 */
-	public const CHART_KEYS = [ 'type', 'activation', 'location' ];
+	public const CHART_KEYS = [ 'type', 'activation', 'conditions', 'location' ];
 
 	/**
 	 * Valid Insights chart view values.
@@ -45,6 +45,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 	public const DEFAULT_VIEWS = [
 		'type'       => 'bar',
 		'activation' => 'pie',
+		'conditions' => 'pie',
 		'location'   => 'bar',
 	];
 

--- a/tests/e2e/code-snippets-insights.spec.ts
+++ b/tests/e2e/code-snippets-insights.spec.ts
@@ -44,6 +44,9 @@ test.describe('Insights screen', () => {
 		await expect(page).toHaveURL(/page=code-snippets-insights/)
 		await expect(page.getByRole('heading', { name: 'Insights' })).toBeVisible()
 		await expect(page.locator('.insights-chart-card').first()).toHaveAttribute('data-insights-chart', 'total')
+		expect(await page.locator('[data-insights-chart]').evaluateAll(charts =>
+			charts.map(chart => chart.getAttribute('data-insights-chart')))).toEqual(
+			['total', 'type', 'activation', 'conditions', 'location', 'tags'])
 		await expect(totalChart.locator('.insights-number-chart-value')).toHaveText('0')
 		await expect(totalChart.locator('.insights-number-chart-label')).toHaveText('Total snippets')
 		await expect(totalChart.locator('.insights-chart-view-toggle')).toHaveCount(0)
@@ -87,14 +90,21 @@ test.describe('Insights screen', () => {
 		})
 		await page.goto(URLS.SNIPPETS_ADMIN.replace('page=snippets', 'page=code-snippets-insights'))
 		const activationPie = page.locator('[data-insights-chart="activation"] .insights-pie-chart')
+		const conditionsChart = page.locator('[data-insights-chart="conditions"]')
 
 		await expect(page.getByRole('heading', { name: 'Insights' })).toBeVisible()
 		await expect(page.locator('[data-insights-chart="total"] .insights-number-chart-value')).toHaveText('5')
 		await expect(page.getByRole('heading', { name: 'Snippet type' })).toBeVisible()
 		await expect(page.getByRole('heading', { name: 'Activation status' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Condition usage' })).toBeVisible()
 		await expect(page.getByRole('heading', { name: 'Location' })).toBeVisible()
 		await expect(page.getByText('Conditions', { exact: true })).toBeVisible()
 		expect(await activationPie.evaluate(element => element.style.background)).toContain('60%')
+		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
+		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('Uses conditions')
+		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('Does not use conditions')
+		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('1')
+		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('4')
 	})
 
 	test('shows used tags in a fixed bar chart', async ({ page }) => {
@@ -172,12 +182,15 @@ test.describe('Insights screen', () => {
 
 		const typeChart = page.locator('[data-insights-chart="type"]')
 		const activationChart = page.locator('[data-insights-chart="activation"]')
+		const conditionsChart = page.locator('[data-insights-chart="conditions"]')
 		const locationChart = page.locator('[data-insights-chart="location"]')
 
 		await expect(typeChart).toHaveAttribute('data-view', 'bar')
 		await expect(typeChart.locator('.insights-bar-chart')).toBeVisible()
 		await expect(activationChart).toHaveAttribute('data-view', 'pie')
 		await expect(activationChart.locator('.insights-pie-chart-legend')).toBeVisible()
+		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
+		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toBeVisible()
 		await expect(locationChart).toHaveAttribute('data-view', 'bar')
 
 		const switchView = async (chart: typeof typeChart, view: 'Pie' | 'Bar') => {
@@ -199,6 +212,11 @@ test.describe('Insights screen', () => {
 		await expect(activationChart.locator('.insights-bar-chart')).toContainText('Active')
 		await expect(activationChart.locator('.insights-bar-chart')).toContainText('Inactive')
 
+		await switchView(conditionsChart, 'Bar')
+		await expect(conditionsChart).toHaveAttribute('data-view', 'bar')
+		await expect(conditionsChart.locator('.insights-bar-chart')).toContainText('Uses conditions')
+		await expect(conditionsChart.locator('.insights-bar-chart')).toContainText('Does not use conditions')
+
 		await switchView(locationChart, 'Pie')
 		await expect(locationChart).toHaveAttribute('data-view', 'pie')
 		await expect(locationChart.locator('.insights-pie-chart-legend')).toHaveCount(1)
@@ -206,22 +224,23 @@ test.describe('Insights screen', () => {
 		await page.reload()
 		await expect(typeChart).toHaveAttribute('data-view', 'pie')
 		await expect(activationChart).toHaveAttribute('data-view', 'bar')
+		await expect(conditionsChart).toHaveAttribute('data-view', 'bar')
 		await expect(locationChart).toHaveAttribute('data-view', 'pie')
 	})
 
 	test('restores a chart view when saving the preference fails', async ({ page }) => {
 		await page.goto(URLS.SNIPPETS_ADMIN.replace('page=snippets', 'page=code-snippets-insights'))
-		const typeChart = page.locator('[data-insights-chart="type"]')
+		const conditionsChart = page.locator('[data-insights-chart="conditions"]')
 
-		await expect(typeChart).toHaveAttribute('data-view', 'bar')
+		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
 
 		await page.route('**/preferences/insights-chart-views', async route => {
 			await route.fulfill({ status: 500, body: JSON.stringify({ message: 'Save failed' }) })
 		})
 
-		await typeChart.getByRole('button', { name: 'Pie chart view' }).click()
+		await conditionsChart.getByRole('button', { name: 'Bar chart view' }).click()
 
-		await expect(typeChart).toHaveAttribute('data-view', 'bar')
+		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
 	})
 
 	test('keeps the latest chart views when an earlier save fails', async ({ page }) => {

--- a/tests/e2e/code-snippets-insights.spec.ts
+++ b/tests/e2e/code-snippets-insights.spec.ts
@@ -101,10 +101,19 @@ test.describe('Insights screen', () => {
 		await expect(page.getByText('Conditions', { exact: true })).toBeVisible()
 		expect(await activationPie.evaluate(element => element.style.background)).toContain('60%')
 		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
-		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('Uses conditions')
-		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('Does not use conditions')
-		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('1')
-		await expect(conditionsChart.locator('.insights-pie-chart-legend')).toContainText('4')
+
+		const conditionLegend = conditionsChart.locator('.insights-pie-chart-legend')
+		const withConditions = conditionLegend.locator('li').filter({
+			hasText: /^Uses conditions/
+		})
+		const withoutConditions = conditionLegend.locator('li').filter({
+			hasText: /^Does not use conditions/
+		})
+
+		await expect(withConditions.locator('span')).toHaveText('Uses conditions')
+		await expect(withConditions.locator('strong')).toHaveText('1')
+		await expect(withoutConditions.locator('span')).toHaveText('Does not use conditions')
+		await expect(withoutConditions.locator('strong')).toHaveText('4')
 	})
 
 	test('shows used tags in a fixed bar chart', async ({ page }) => {

--- a/tests/unit/Admin/Menus/Insights/Insights_Menu_Test.php
+++ b/tests/unit/Admin/Menus/Insights/Insights_Menu_Test.php
@@ -42,7 +42,7 @@ class Insights_Menu_Test extends AdminUnitTestCase {
 		$localized = json_decode( substr( $json, 0, strrpos( $json, ';' ) ), true );
 
 		$this->assertSame(
-			[ 'active', 'inactive', 'typeCounts', 'locationCounts', 'tagCounts' ],
+			[ 'active', 'inactive', 'typeCounts', 'conditionCounts', 'locationCounts', 'tagCounts' ],
 			array_keys( $localized )
 		);
 	}

--- a/tests/unit/Admin/Menus/Insights/Insights_Summary_Test.php
+++ b/tests/unit/Admin/Menus/Insights/Insights_Summary_Test.php
@@ -27,6 +27,19 @@ class Insights_Summary_Test extends AdminUnitTestCase {
 		$this->assertSame( [ 'php', 'html', 'css', 'js', 'cond' ], array_keys( $summary['typeCounts'] ) );
 		$this->assertSame( 0, $summary['typeCounts']['php']['count'] );
 		$this->assertSame( 0, $summary['typeCounts']['cond']['count'] );
+		$this->assertSame(
+			[
+				'with' => [
+					'label' => 'Uses conditions',
+					'count' => 0,
+				],
+				'without' => [
+					'label' => 'Does not use conditions',
+					'count' => 0,
+				],
+			],
+			$summary['conditionCounts']
+		);
 		$this->assertSame( [], $summary['locationCounts'] );
 		$this->assertSame( [], $summary['tagCounts'] );
 	}
@@ -251,6 +264,19 @@ class Insights_Summary_Test extends AdminUnitTestCase {
 		$this->assertSame( 1, $summary['typeCounts']['css']['count'] );
 		$this->assertSame( 1, $summary['typeCounts']['js']['count'] );
 		$this->assertSame( 1, $summary['typeCounts']['cond']['count'] );
+		$this->assertSame(
+			[
+				'with' => [
+					'label' => 'Uses conditions',
+					'count' => 1,
+				],
+				'without' => [
+					'label' => 'Does not use conditions',
+					'count' => 6,
+				],
+			],
+			$summary['conditionCounts']
+		);
 		$this->assertSame( 2, $summary['locationCounts']['global'] );
 		$this->assertSame( 1, $summary['locationCounts']['site-css'] );
 		$this->assertArrayNotHasKey( 'condition', $summary['locationCounts'] );

--- a/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
+++ b/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
@@ -92,6 +92,7 @@ class Insights_View_Rest_Controller_Test extends AdminUnitTestCase {
 		$views = [
 			'type'       => 'pie',
 			'activation' => 'bar',
+			'conditions' => 'bar',
 			'location'   => 'pie',
 		];
 		$response = $this->dispatch( 'POST', [ 'views' => $views ] );
@@ -130,6 +131,7 @@ class Insights_View_Rest_Controller_Test extends AdminUnitTestCase {
 			[
 				'type'       => 'pie',
 				'activation' => 'pie',
+				'conditions' => 'pie',
 				'location'   => 'bar',
 			],
 			Insights_View_Rest_Controller::get_insights_chart_views()


### PR DESCRIPTION
This PR adds a new chart to the insights page, displaying condition usage.

<img width="1339" height="629" alt="image" src="https://github.com/user-attachments/assets/2a2adacd-682b-4fcc-9302-307ba42d9c7b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Conditions chart to the Insights dashboard.
  - View snippet usage by whether conditions are present or absent.
  - Switch between pie and bar chart formats.
  - Your selected chart format is saved and restored automatically.
  - Added clear labels and color coding for condition usage.

- **Bug Fixes**
  - Failed preference saves now correctly restore the previous chart selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->