### PR TITLE
refactor: replace hardcoded URLs with constants in e2e Playwright tests

### DIFF
--- a/tests/e2e/admin-screen-headings.spec.ts
+++ b/tests/e2e/admin-screen-headings.spec.ts
@@ -3,9 +3,9 @@ import { URLS } from './helpers/constants'
 
 const EXPECTED_H1_HEADING_COUNT = 1
 
-const SCREENS = [
-	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN },
+const SCREENS: { name: string; url: string }[] = [
 	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
+	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN },
 	{ name: 'Cloud Community', url: URLS.CLOUD_COMMUNITY_ADMIN },
 	{ name: 'Cloud Library', url: URLS.CLOUD_LIBRARY_ADMIN },
 	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },

--- a/tests/e2e/admin-screen-headings.spec.ts
+++ b/tests/e2e/admin-screen-headings.spec.ts
@@ -6,14 +6,14 @@ const EXPECTED_H1_HEADING_COUNT = 1
 const SCREENS = [
 	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN },
 	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
-	{ name: 'Community Cloud', url: URLS.COMMUNITY_CLOUD_ADMIN },
-	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },
+	{ name: 'Cloud Community', url: URLS.CLOUD_COMMUNITY_ADMIN },
 	{ name: 'Cloud Library', url: URLS.CLOUD_LIBRARY_ADMIN },
+	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },
 	{ name: 'AI Agent', url: URLS.AI_AGENT_ADMIN },
 	{ name: 'Insights', url: URLS.INSIGHTS_ADMIN },
-	{ name: 'Import', url: URLS.IMPORT_SNIPPETS_ADMIN },
+	{ name: 'Import', url: URLS.IMPORT_ADMIN },
 	{ name: 'Settings', url: URLS.SETTINGS_ADMIN },
-	{ name: 'Welcome', url: URLS.WELCOME_SCREEN_ADMIN }
+	{ name: 'Welcome', url: URLS.WELCOME_ADMIN }
 ]
 
 test.describe('Admin screen headings', () => {

--- a/tests/e2e/ai-agent-demo.spec.ts
+++ b/tests/e2e/ai-agent-demo.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '@playwright/test'
-import { TIMEOUTS } from './helpers/constants'
+import { TIMEOUTS, URLS } from './helpers/constants'
 import { measureCalloutSteps } from './helpers/demoPacing'
 import { wpCli } from './helpers/wpCli'
 
-const DEMO_URL = '/wp-admin/admin.php?page=snippets&subpage=ai-agent'
 const DEMO_NAMES = "'Welcome banner', 'Welcome banner styles'"
 
 const countDemoSnippets = async (): Promise<number> => {
@@ -22,7 +21,7 @@ test.describe('AI Agent demo', () => {
 	test.afterAll(forgetDemos)
 
 	test('the tab is reachable from the toolbar and highlighted as new', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=snippets')
+		await page.goto(URLS.SNIPPETS_ADMIN)
 
 		const link = page.locator('.code-snippets-toolbar-lower a.ai-agent-link')
 		await expect(link).toBeVisible()
@@ -36,7 +35,7 @@ test.describe('AI Agent demo', () => {
 	})
 
 	test('the page opens on the agent\u2019s own layout, with its starter prompts and sidebar', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.AI_AGENT_ADMIN)
 
 		await expect(page.locator('.ai-agent-empty__chip')).toHaveCount(5)
 		await expect(page.locator('.ai-agent-layout__main > .ai-agent-prompt')).toBeVisible()
@@ -50,7 +49,7 @@ test.describe('AI Agent demo', () => {
 	})
 
 	test('playing the walkthrough plans, builds and refines without touching the site', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.AI_AGENT_ADMIN)
 		expect(await countDemoSnippets()).toBe(0)
 
 		await page.locator('.demo-play').click()
@@ -75,7 +74,7 @@ test.describe('AI Agent demo', () => {
 	})
 
 	test('the walkthrough never writes a snippet, however many times it runs', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.AI_AGENT_ADMIN)
 
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
@@ -93,7 +92,7 @@ test.describe('AI Agent demo', () => {
 
 	test('the walkthrough ends with the closing panel below the agent, scrolled into view', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 })
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.AI_AGENT_ADMIN)
 
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
@@ -106,7 +105,7 @@ test.describe('AI Agent demo', () => {
 	})
 
 	test('the walkthrough holds each step long enough to be read', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.AI_AGENT_ADMIN)
 		await page.locator('.demo-play').click()
 
 		const steps = await measureCalloutSteps(page)

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,6 +1,7 @@
 import { join } from 'path'
 import { expect, test as setup } from '@playwright/test'
 import { wpCli } from './helpers/wpCli'
+import { URLS } from './helpers/constants'
 
 const authFile = join(__dirname, '.auth/user.json')
 const AUTH_SETUP_TIMEOUT_MS = 120000
@@ -34,7 +35,7 @@ setup('authenticate', async ({ page }) => {
 		])
 	}
 
-	await page.goto('/wp-login.php')
+	await page.goto(URLS.WP_LOGIN)
 	await page.waitForSelector('#user_login')
 
 	await page.fill('#user_login', 'admin')

--- a/tests/e2e/blueprints-demo.spec.ts
+++ b/tests/e2e/blueprints-demo.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from '@playwright/test'
-import { TIMEOUTS } from './helpers/constants'
+import { TIMEOUTS, URLS } from './helpers/constants'
 import { measureCalloutSteps } from './helpers/demoPacing'
 import { wpCli } from './helpers/wpCli'
 import type { Page } from '@playwright/test'
 
-const DEMO_URL = '/wp-admin/admin.php?page=snippets&subpage=blueprints'
 const SECTIONS = ['General', 'Attributes', 'Output']
 
 const forgetDemos = () => wpCli(['option', 'delete', 'code_snippets_demos_seen'])
@@ -17,7 +16,7 @@ test.describe('Blueprints demo', () => {
 	test.afterAll(forgetDemos)
 
 	test('the tab is reachable from the toolbar and highlighted as new', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=snippets')
+		await page.goto(URLS.SNIPPETS_ADMIN)
 
 		const link = page.locator('.code-snippets-toolbar-lower a.blueprints-link')
 		await expect(link).toBeVisible()
@@ -31,7 +30,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('the blueprint is shown prepopulated before play', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 
 		await expect(page.locator('.blueprint-detail__header h2')).toHaveText('Create a Shortcode')
 		await expect(page.locator('.blueprint-form-content h3')).toHaveText('General')
@@ -44,7 +43,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('playing steps through every section and confirms a generated snippet', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await page.locator('.demo-play').click()
 
 		for (const section of SECTIONS) {
@@ -65,7 +64,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('sections become browsable once the walkthrough finishes', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 
 		await expect(page.locator('.blueprint-form-sidebar__item').first()).toBeDisabled()
 
@@ -82,7 +81,7 @@ test.describe('Blueprints demo', () => {
 
 	test('every section is the same height', async ({ page }) => {
 		await page.setViewportSize({ width: 1600, height: 950 })
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
@@ -104,7 +103,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('the toolbar badge softens to Demo once the walkthrough has been watched', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await expect(page.locator('.code-snippets-toolbar-lower a.blueprints-link .new-chip')).toBeVisible()
 
 		await page.locator('.demo-play').click()
@@ -115,7 +114,7 @@ test.describe('Blueprints demo', () => {
 		await expect.poll(async () =>
 			(await wpCli(['option', 'get', 'code_snippets_demos_seen'])).includes('blueprints')).toBe(true)
 
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 
 		const link = page.locator('.code-snippets-toolbar-lower a.blueprints-link')
 		await expect(link.locator('.demo-chip')).toHaveText('Demo')
@@ -123,7 +122,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('the demo-reset URL puts the badge back to New', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
 		await expect(page.locator('.demo-upsell')).toBeVisible()
@@ -132,7 +131,7 @@ test.describe('Blueprints demo', () => {
 			(await wpCli(['option', 'get', 'code_snippets_demos_seen'])).includes('blueprints')).toBe(true)
 
 		const link = page.locator('.code-snippets-toolbar-lower a.blueprints-link')
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await expect(link.locator('.demo-chip')).toBeVisible()
 
 		// The reset is nonce-protected, so the signed address is taken from the
@@ -145,13 +144,13 @@ test.describe('Blueprints demo', () => {
 		await expect(page).toHaveURL(/page=snippets/)
 		await expect(page).not.toHaveURL(/demo-reset/)
 
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await expect(link.locator('.new-chip')).toHaveText('New')
 		await expect(link.locator('.demo-chip')).toHaveCount(0)
 	})
 
 	test('replaying restarts from the first section', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
 
@@ -163,7 +162,7 @@ test.describe('Blueprints demo', () => {
 	})
 
 	test('the walkthrough holds each step long enough to be read', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.BLUEPRINTS_ADMIN)
 		await page.locator('.demo-play').click()
 
 		const steps = await measureCalloutSteps(page)

--- a/tests/e2e/cloud-download-eligibility.spec.ts
+++ b/tests/e2e/cloud-download-eligibility.spec.ts
@@ -68,7 +68,7 @@ const routeCloudSnippets = (page: Page, state: CloudRoutesState) =>
 	})
 
 const openCommunityCloud = async (page: Page, view: 'table' | 'card') => {
-	await page.goto(URLS.COMMUNITY_CLOUD_ADMIN)
+	await page.goto(URLS.CLOUD_COMMUNITY_ADMIN)
 	await expect(page.locator('.cloud-search')).toBeVisible()
 	await page.getByTitle(`Switch to ${view} view`).click()
 }

--- a/tests/e2e/cloud-library-demo.spec.ts
+++ b/tests/e2e/cloud-library-demo.spec.ts
@@ -1,13 +1,12 @@
 import { expect, test } from '@playwright/test'
-import { TIMEOUTS } from './helpers/constants'
+import { TIMEOUTS, URLS } from './helpers/constants'
 import { measureCalloutSteps } from './helpers/demoPacing'
 
-const DEMO_URL = '/wp-admin/admin.php?page=snippets&subpage=cloud-library'
 const FEATURED_ROW = '.cloud-library-snippets tbody tr.demo-featured-row'
 
 test.describe('Cloud Library demo', () => {
 	test('the tab carries a demo badge rather than announcing itself as new', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=snippets')
+		await page.goto(URLS.SNIPPETS_ADMIN)
 
 		const link = page.locator('.code-snippets-toolbar-lower a.cloud-library-link')
 		await expect(link).toBeVisible()
@@ -21,7 +20,7 @@ test.describe('Cloud Library demo', () => {
 	})
 
 	test('the library is shown as a table on its own before play', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 
 		// Deliberately a short library, so the closing panel is reachable.
 		await expect(page.locator('.cloud-library-snippets tbody tr')).toHaveCount(4)
@@ -36,7 +35,7 @@ test.describe('Cloud Library demo', () => {
 	})
 
 	test('playing previews, downloads, and leaves the snippet synced', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 		await page.locator('.demo-play').click()
 
 		// The code preview opens on its own, then closes before the download.
@@ -58,7 +57,7 @@ test.describe('Cloud Library demo', () => {
 
 	test('the preview step keeps its callout in place, over the modal overlay', async ({ page }) => {
 		await page.setViewportSize({ width: 1600, height: 900 })
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 		await page.locator('.demo-play').click()
 
 		const modal = page.locator('.code-snippets-preview-modal')
@@ -90,7 +89,7 @@ test.describe('Cloud Library demo', () => {
 	})
 
 	test('each step marks the click and spotlights what it describes', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 		await page.locator('.demo-play').click()
 
 		const spotlight = page.locator('.demo-spotlight')
@@ -115,7 +114,7 @@ test.describe('Cloud Library demo', () => {
 
 	test('the walkthrough ends scrolled to the closing panel', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 })
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
@@ -131,7 +130,7 @@ test.describe('Cloud Library demo', () => {
 	})
 
 	test('replaying returns the snippet to its undownloaded state', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 		await page.locator('.demo-play').click()
 		await page.getByRole('button', { name: 'Skip animation' }).click()
 
@@ -144,7 +143,7 @@ test.describe('Cloud Library demo', () => {
 	})
 
 	test('the walkthrough holds each step long enough to be read', async ({ page }) => {
-		await page.goto(DEMO_URL)
+		await page.goto(URLS.CLOUD_LIBRARY_ADMIN)
 		await page.locator('.demo-play').click()
 
 		const steps = await measureCalloutSteps(page)

--- a/tests/e2e/code-snippets-community-featured.spec.ts
+++ b/tests/e2e/code-snippets-community-featured.spec.ts
@@ -25,7 +25,7 @@ const closePreviewIfOpen = async (page: Page) => {
 }
 
 const openCommunityCloud = async (page: Page) => {
-	await page.goto(URLS.COMMUNITY_CLOUD_ADMIN)
+	await page.goto(URLS.CLOUD_COMMUNITY_ADMIN)
 	await page.waitForLoadState('domcontentloaded')
 }
 

--- a/tests/e2e/code-snippets-evaluation.spec.ts
+++ b/tests/e2e/code-snippets-evaluation.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { DEFAULT_E2E_SNIPPET_BASE_NAME, SnippetsTestHelper } from './helpers/SnippetsTestHelper'
-import { SELECTORS } from './helpers/constants'
+import { SELECTORS, URLS } from './helpers/constants'
 import { wpCli } from './helpers/wpCli'
 import type { Page } from '@playwright/test'
 
@@ -113,7 +113,7 @@ test.describe('Code Snippets Evaluation', () => {
 			code: BODY_CLASS_TEST_CODE
 		})
 
-		await page.goto('/wp-admin/')
+		await page.goto(URLS.WP_ADMIN)
 		await expect(page.locator('body')).toHaveClass(/custom-admin-class/)
 
 		await helper.navigateToFrontend()
@@ -127,7 +127,7 @@ test.describe('Code Snippets Evaluation', () => {
 			code: BODY_CLASS_TEST_CODE
 		})
 
-		await page.goto('/wp-admin/')
+		await page.goto(URLS.WP_ADMIN)
 		await expect(page.locator('body')).toHaveClass(/custom-admin-class/)
 
 		await helper.navigateToFrontend()
@@ -141,7 +141,7 @@ test.describe('Code Snippets Evaluation', () => {
 			code: BODY_CLASS_TEST_CODE
 		})
 
-		await page.goto('/wp-admin/')
+		await page.goto(URLS.WP_ADMIN)
 		await expect(page.locator('body')).not.toHaveClass(/custom-admin-class/)
 
 		await helper.navigateToFrontend()

--- a/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
+++ b/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { SnippetsTestHelper } from './helpers/SnippetsTestHelper'
 import { wpCli } from './helpers/wpCli'
+import { URLS } from './helpers/constants'
 
 const QUICKNAV_PREFIX = 'E2E QuickNav'
 const QUICKNAV_PER_PAGE = 2
@@ -141,7 +142,7 @@ test.describe('Admin Bar Snippets QuickNav', () => {
 
 		await removeMuPlugin()
 
-		await page.goto('/wp-admin/admin.php?page=snippets')
+		await page.goto(URLS.SNIPPETS_ADMIN)
 		await expect(page.locator('#wp-admin-bar-code-snippets-safe-mode')).toHaveCount(0)
 
 		try {
@@ -158,7 +159,7 @@ test.describe('Admin Bar Snippets QuickNav', () => {
 				`
 			])
 
-			await page.goto('/wp-admin/admin.php?page=snippets')
+			await page.goto(URLS.SNIPPETS_ADMIN)
 			const safeModeNode = page.locator('#wp-admin-bar-code-snippets-safe-mode')
 			await expect(safeModeNode).toBeVisible({ timeout: 30000 })
 
@@ -169,7 +170,7 @@ test.describe('Admin Bar Snippets QuickNav', () => {
 			await removeMuPlugin()
 		}
 
-		await page.goto('/wp-admin/admin.php?page=snippets')
+		await page.goto(URLS.SNIPPETS_ADMIN)
 		await expect(page.locator('#wp-admin-bar-code-snippets-safe-mode')).toHaveCount(0)
 	})
 })

--- a/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
+++ b/tests/e2e/code-snippets-quicknav-admin-bar.spec.ts
@@ -89,7 +89,7 @@ test.describe('Admin Bar Snippets QuickNav', () => {
 		const errors: string[] = []
 		page.on('pageerror', error => errors.push(error.message))
 
-		await page.goto('/')
+		await page.goto(URLS.FRONTEND)
 
 		// The admin bar bundle is enqueued on the front end as well as in wp-admin,
 		// but `wp.i18n`, `wp.url` and `pagenow` are only present in wp-admin unless

--- a/tests/e2e/editor-labels.spec.ts
+++ b/tests/e2e/editor-labels.spec.ts
@@ -1,18 +1,19 @@
 import { expect, test } from '@playwright/test'
+import { URLS } from './helpers/constants'
 
 // CodeMirror replaces the labelled textarea with an input of its own, so the
 // name a screen reader hears comes from the attribute the plugin sets on that
 // input after the editor starts. One check per editor the plugin creates.
 test.describe('Code editor labels', () => {
 	test('the snippet editor input is named', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=add-snippet')
+		await page.goto(URLS.ADD_SNIPPET_ADMIN)
 		await page.waitForSelector('.CodeMirror')
 
 		await expect(page.locator('.snippet-editor .CodeMirror textarea')).toHaveAttribute('aria-label', 'Snippet code')
 	})
 
 	test('the settings preview input is named', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=snippets-settings&section=editing')
+		await page.goto(`${URLS.SETTINGS_ADMIN}&section=editing`)
 		await page.waitForSelector('.CodeMirror')
 
 		await expect(page.locator('.CodeMirror textarea').first()).toHaveAttribute('aria-label', 'Code editor preview')

--- a/tests/e2e/feedback-reporter.spec.ts
+++ b/tests/e2e/feedback-reporter.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '@playwright/test'
 import { wpCli } from './helpers/wpCli'
+import { URLS } from './helpers/constants'
 import type { Page } from '@playwright/test'
 
-const SNIPPETS_URL = '/wp-admin/admin.php?page=snippets'
-const SETTINGS_URL = '/wp-admin/admin.php?page=snippets-settings&section=advanced'
 const LAUNCHER = '.code-snippets-feedback-launcher'
 const PANEL = '.code-snippets-feedback-modal'
 
@@ -19,7 +18,7 @@ const setReporterEnabled = async (enabled: boolean): Promise<void> => {
 }
 
 const openPanel = async (page: Page): Promise<void> => {
-	await page.goto(SNIPPETS_URL)
+	await page.goto(URLS.SNIPPETS_ADMIN)
 	await page.locator(LAUNCHER).click()
 	await expect(page.locator(PANEL)).toBeVisible()
 }
@@ -31,13 +30,13 @@ test.describe('Feedback reporter', () => {
 
 	test('stays hidden until the setting is switched on', async ({ page }) => {
 		await setReporterEnabled(false)
-		await page.goto(SNIPPETS_URL)
+		await page.goto(URLS.SNIPPETS_ADMIN)
 
 		await expect(page.locator(LAUNCHER)).toHaveCount(0)
 	})
 
 	test('is offered on the Advanced settings tab', async ({ page }) => {
-		await page.goto(SETTINGS_URL)
+		await page.goto(`${URLS.SETTINGS_ADMIN}&section=advanced`)
 
 		await expect(page.locator('input[name*="enable_feedback_reporter"]')).toHaveCount(1)
 	})

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -38,6 +38,8 @@ export const URLS = <const> {
 	IMPORT_SNIPPETS_ADMIN: '/wp-admin/admin.php?page=import-code-snippets',
 	SETTINGS_ADMIN: '/wp-admin/admin.php?page=snippets-settings',
 	WELCOME_SCREEN_ADMIN: '/wp-admin/admin.php?page=code-snippets-welcome',
+	WP_ADMIN: '/wp-admin/',
+	WP_LOGIN: '/wp-login.php',
 	FRONTEND: '/'
 }
 

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -28,19 +28,19 @@ export const TIMEOUTS = <const> {
 }
 
 export const URLS = <const> {
+	FRONTEND: '/',
+	WP_ADMIN: '/wp-admin/',
+	WP_LOGIN: '/wp-login.php',
 	SNIPPETS_ADMIN: '/wp-admin/admin.php?page=snippets',
-	COMMUNITY_CLOUD_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=cloud-community',
-	BLUEPRINTS_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=blueprints',
+	CLOUD_COMMUNITY_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=cloud-community',
 	CLOUD_LIBRARY_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=cloud-library',
+	BLUEPRINTS_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=blueprints',
 	AI_AGENT_ADMIN: '/wp-admin/admin.php?page=snippets&subpage=ai-agent',
 	ADD_SNIPPET_ADMIN: '/wp-admin/admin.php?page=add-snippet',
 	INSIGHTS_ADMIN: '/wp-admin/admin.php?page=code-snippets-insights',
-	IMPORT_SNIPPETS_ADMIN: '/wp-admin/admin.php?page=import-code-snippets',
+	IMPORT_ADMIN: '/wp-admin/admin.php?page=import-code-snippets',
 	SETTINGS_ADMIN: '/wp-admin/admin.php?page=snippets-settings',
-	WELCOME_SCREEN_ADMIN: '/wp-admin/admin.php?page=code-snippets-welcome',
-	WP_ADMIN: '/wp-admin/',
-	WP_LOGIN: '/wp-login.php',
-	FRONTEND: '/'
+	WELCOME_ADMIN: '/wp-admin/admin.php?page=code-snippets-welcome'
 }
 
 export const MESSAGES = <const> {

--- a/tests/e2e/list-toolbar-fit.spec.ts
+++ b/tests/e2e/list-toolbar-fit.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test'
-
-const SNIPPETS_URL = '/wp-admin/admin.php?page=snippets'
+import { URLS } from './helpers/constants'
 
 // The toolbar's end group (pagination plus the view toggle) cannot shrink, so at
 // widths where the row does not fit it must wrap rather than spill off the page.
@@ -10,7 +9,7 @@ test.describe('Snippets toolbar fit', () => {
 	for (const width of [1280, 1360, 1400, 1401, 1600]) {
 		test(`nothing spills out of the toolbar at ${width}px`, async ({ page }) => {
 			await page.setViewportSize({ width, height: 900 })
-			await page.goto(SNIPPETS_URL)
+			await page.goto(URLS.SNIPPETS_ADMIN)
 			await page.waitForSelector('.snippet-view-toggle')
 
 			const fit = await page.evaluate(() => {

--- a/tests/e2e/rtl-layout.spec.ts
+++ b/tests/e2e/rtl-layout.spec.ts
@@ -5,12 +5,12 @@ import { URLS } from './helpers/constants'
 // direction multiplier and logical properties; what can still go wrong is a
 // control pushed past the page edge or a row that no longer fits, so every
 // screen is checked for those rather than for how it looks.
-const SCREENS: [string, string, string][] = [
-	['settings, editing tab', `${URLS.SETTINGS_ADMIN}&section=editing`, '#settings-sections-tabs'],
-	['settings, advanced tab', `${URLS.SETTINGS_ADMIN}&section=advanced`, '#settings-sections-tabs'],
-	['snippets list', URLS.SNIPPETS_ADMIN, '.snippet-view-toggle'],
-	['new snippet', URLS.ADD_SNIPPET_ADMIN, '.CodeMirror'],
-	['import', URLS.IMPORT_ADMIN, '#wpbody-content']
+const SCREENS: { name: string; url: string; ready: string }[] = [
+	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN, ready: '.CodeMirror' },
+	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN, ready: '.snippet-view-toggle' },
+	{ name: 'Import', url: URLS.IMPORT_ADMIN, ready: '#wpbody-content' },
+	{ name: 'Settings (editing tab)', url: `${URLS.SETTINGS_ADMIN}&section=editing`, ready: '#settings-sections-tabs' },
+	{ name: 'Settings (advanced tab)', url: `${URLS.SETTINGS_ADMIN}&section=advanced`, ready: '#settings-sections-tabs' }
 ]
 
 interface LayoutReport {
@@ -45,7 +45,7 @@ const inspect = (): LayoutReport => {
 }
 
 test.describe('Right-to-left layout', () => {
-	for (const [name, url, ready] of SCREENS) {
+	for (const { name, url, ready } of SCREENS) {
 		test(`${name} mirrors without spilling off the page`, async ({ page }) => {
 			await page.setViewportSize({ width: 1360, height: 900 })
 			await page.goto(url)

--- a/tests/e2e/rtl-layout.spec.ts
+++ b/tests/e2e/rtl-layout.spec.ts
@@ -10,7 +10,7 @@ const SCREENS: [string, string, string][] = [
 	['settings, advanced tab', `${URLS.SETTINGS_ADMIN}&section=advanced`, '#settings-sections-tabs'],
 	['snippets list', URLS.SNIPPETS_ADMIN, '.snippet-view-toggle'],
 	['new snippet', URLS.ADD_SNIPPET_ADMIN, '.CodeMirror'],
-	['import', URLS.IMPORT_SNIPPETS_ADMIN, '#wpbody-content']
+	['import', URLS.IMPORT_ADMIN, '#wpbody-content']
 ]
 
 interface LayoutReport {

--- a/tests/e2e/rtl-layout.spec.ts
+++ b/tests/e2e/rtl-layout.spec.ts
@@ -1,15 +1,16 @@
 import { expect, test } from '@playwright/test'
+import { URLS } from './helpers/constants'
 
 // The admin screens under a right-to-left locale. Mirroring is driven by the
 // direction multiplier and logical properties; what can still go wrong is a
 // control pushed past the page edge or a row that no longer fits, so every
 // screen is checked for those rather than for how it looks.
 const SCREENS: [string, string, string][] = [
-	['settings, editing tab', '/wp-admin/admin.php?page=snippets-settings&section=editing', '#settings-sections-tabs'],
-	['settings, advanced tab', '/wp-admin/admin.php?page=snippets-settings&section=advanced', '#settings-sections-tabs'],
-	['snippets list', '/wp-admin/admin.php?page=snippets', '.snippet-view-toggle'],
-	['new snippet', '/wp-admin/admin.php?page=add-snippet', '.CodeMirror'],
-	['import', '/wp-admin/admin.php?page=import-code-snippets', '#wpbody-content']
+	['settings, editing tab', `${URLS.SETTINGS_ADMIN}&section=editing`, '#settings-sections-tabs'],
+	['settings, advanced tab', `${URLS.SETTINGS_ADMIN}&section=advanced`, '#settings-sections-tabs'],
+	['snippets list', URLS.SNIPPETS_ADMIN, '.snippet-view-toggle'],
+	['new snippet', URLS.ADD_SNIPPET_ADMIN, '.CodeMirror'],
+	['import', URLS.IMPORT_SNIPPETS_ADMIN, '#wpbody-content']
 ]
 
 interface LayoutReport {

--- a/tests/e2e/rtl.setup.ts
+++ b/tests/e2e/rtl.setup.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from 'fs'
 import { expect, test as setup } from '@playwright/test'
 import { RTL_LOCALE, RTL_USER, rtlAuthFile, rtlCreatedMarker } from './helpers/rtlUser'
 import { wpCli } from './helpers/wpCli'
+import { URLS } from './helpers/constants'
 
 // The RTL specs sign in as a user of their own whose locale is right-to-left,
 // so the rest of the suite, which signs in as the usual admin, never sees the
@@ -32,7 +33,7 @@ setup('sign in as a right-to-left user', async ({ page }) => {
 	writeFileSync(rtlCreatedMarker, created ? 'created' : 'existing')
 	await wpCli(['user', 'update', RTL_USER, '--user_pass=password', `--locale=${RTL_LOCALE}`])
 
-	await page.goto('/wp-login.php')
+	await page.goto(URLS.WP_LOGIN)
 	await page.waitForSelector('#user_login')
 	await page.fill('#user_login', RTL_USER)
 	await page.fill('#user_pass', 'password')

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -8,7 +8,7 @@ const SCREENS = [
 	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },
 	{ name: 'AI Agent', url: URLS.AI_AGENT_ADMIN },
 	{ name: 'Insights', url: URLS.INSIGHTS_ADMIN },
-	{ name: 'Welcome', url: URLS.WELCOME_SCREEN_ADMIN }
+	{ name: 'Welcome', url: URLS.WELCOME_ADMIN }
 ]
 
 test.describe('Screen meta slot', () => {

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -1,13 +1,16 @@
 import { expect, test } from '@playwright/test'
 import { URLS } from './helpers/constants'
 
-const SCREENS = [
+const SCREENS: { name: string; url: string }[] = [
 	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
-	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN },
+	{ name: 'Manage Snippets', url: `${URLS.SNIPPETS_ADMIN}&subpage=snippets` },
+	{ name: 'Cloud Community', url: URLS.CLOUD_COMMUNITY_ADMIN },
 	{ name: 'Cloud Library', url: URLS.CLOUD_LIBRARY_ADMIN },
 	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },
 	{ name: 'AI Agent', url: URLS.AI_AGENT_ADMIN },
 	{ name: 'Insights', url: URLS.INSIGHTS_ADMIN },
+	{ name: 'Import', url: URLS.IMPORT_ADMIN },
+	{ name: 'Settings', url: URLS.SETTINGS_ADMIN },
 	{ name: 'Welcome', url: URLS.WELCOME_ADMIN }
 ]
 

--- a/tests/e2e/screen-meta-slot.spec.ts
+++ b/tests/e2e/screen-meta-slot.spec.ts
@@ -3,11 +3,11 @@ import { URLS } from './helpers/constants'
 
 const SCREENS = [
 	{ name: 'Add Snippet', url: URLS.ADD_SNIPPET_ADMIN },
-	{ name: 'Manage Snippets', url: `${URLS.SNIPPETS_ADMIN}&subpage=snippets` },
-	{ name: 'Cloud Library', url: '/wp-admin/admin.php?page=snippets&subpage=cloud-library' },
-	{ name: 'Blueprints', url: '/wp-admin/admin.php?page=snippets&subpage=blueprints' },
-	{ name: 'AI Agent', url: '/wp-admin/admin.php?page=snippets&subpage=ai-agent' },
-	{ name: 'Insights', url: '/wp-admin/admin.php?page=code-snippets-insights' },
+	{ name: 'Manage Snippets', url: URLS.SNIPPETS_ADMIN },
+	{ name: 'Cloud Library', url: URLS.CLOUD_LIBRARY_ADMIN },
+	{ name: 'Blueprints', url: URLS.BLUEPRINTS_ADMIN },
+	{ name: 'AI Agent', url: URLS.AI_AGENT_ADMIN },
+	{ name: 'Insights', url: URLS.INSIGHTS_ADMIN },
 	{ name: 'Welcome', url: URLS.WELCOME_SCREEN_ADMIN }
 ]
 

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test'
+import { URLS } from './helpers/constants'
 
-const SETTINGS_URL = '/wp-admin/admin.php?page=snippets-settings&section=editing'
 const TABS = '#settings-sections-tabs'
 
 test.describe('Settings tabs', () => {
 	test('switch between rendered sections in place', async ({ page }) => {
-		await page.goto(SETTINGS_URL)
+		await page.goto(`${URLS.SETTINGS_ADMIN}&section=editing`)
 
 		const wrap = page.locator('.wrap[data-active-tab]')
 		await expect(wrap).toHaveAttribute('data-active-tab', 'editing')

--- a/tests/e2e/toolbar-active-subpage.spec.ts
+++ b/tests/e2e/toolbar-active-subpage.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test'
+import { URLS } from './helpers/constants'
 import type { Page } from '@playwright/test'
-
-const MANAGE_URL = '/wp-admin/admin.php?page=snippets'
 
 // The manage screen resolves an absent or unrecognised `subpage` to the first
 // subpage, so the toolbar must highlight whichever subpage actually rendered.
@@ -21,7 +20,7 @@ const activeSubpageLinks = (page: Page) =>
 test.describe('Toolbar active subpage', () => {
 	for (const { name, query, active, body } of CASES) {
 		test(`the highlighted tab matches the rendered page with ${name}`, async ({ page }) => {
-			await page.goto(`${MANAGE_URL}${query}`)
+			await page.goto(`${URLS.SNIPPETS_ADMIN}${query}`)
 			await expect(page.locator(body)).toBeVisible()
 
 			await expect(activeSubpageLinks(page)).toHaveCount(1)
@@ -30,7 +29,7 @@ test.describe('Toolbar active subpage', () => {
 	}
 
 	test('no lower-nav tab is highlighted away from the manage screen', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=snippets-settings')
+		await page.goto(URLS.SETTINGS_ADMIN)
 
 		await expect(page.locator('.code-snippets-toolbar-lower')).toBeVisible()
 		await expect(activeSubpageLinks(page)).toHaveCount(0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized end-to-end test navigation across admin, login, frontend, snippets, settings, cloud, and blueprint screens.
  * Updated screen labels and shared navigation references for Cloud Community, Import, and Welcome pages.
  * Preserved existing test assertions and coverage while improving consistency of tested destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->