### PR TITLE
feat: add tags cloud view and update related components

### DIFF
--- a/src/css/insights.scss
+++ b/src/css/insights.scss
@@ -14,6 +14,7 @@
 }
 
 .insights-chart-card {
+	min-block-size: 220px;
 	box-sizing: border-box;
 	border: 1px solid var(--cs-color-border-subtle);
 	border-radius: var(--cs-card-radius);
@@ -113,6 +114,21 @@
 	padding: 0;
 	margin: 0;
 	list-style: none;
+}
+
+.insights-tags-cloud {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 8px 12px;
+	padding: 0;
+	margin: 0;
+	list-style: none;
+
+	li {
+		margin: 0;
+		line-height: 1.4;
+	}
 }
 
 .insights-chart-entry-link {

--- a/src/js/components/InsightsMenu/InsightsChartViewToggle.tsx
+++ b/src/js/components/InsightsMenu/InsightsChartViewToggle.tsx
@@ -3,13 +3,15 @@ import classnames from 'classnames'
 import React from 'react'
 import type { InsightsChartView } from '../../types/Insights'
 
-interface ViewToggleButtonProps extends InsightsChartViewToggleProps {
+interface ViewToggleButtonProps<View extends InsightsChartView> extends InsightsChartViewToggleProps<View> {
 	icon: string
 	label: string
-	currentView: InsightsChartView
+	currentView: View
 }
 
-const ViewToggleButton: React.FC<ViewToggleButtonProps> = ({ icon, title, label, view, setView, currentView }) =>
+const ViewToggleButton = <View extends InsightsChartView,>(
+	{ icon, title, label, view, setView, currentView }: ViewToggleButtonProps<View>
+) =>
 	<button
 		type="button"
 		className={classnames('insights-chart-view-toggle-option', { 'active-view': currentView === view })}
@@ -21,11 +23,11 @@ const ViewToggleButton: React.FC<ViewToggleButtonProps> = ({ icon, title, label,
 		<span className="screen-reader-text">{label}</span>
 	</button>
 
-export interface InsightsChartViewToggleProps {
+export interface InsightsChartViewToggleProps<View extends InsightsChartView> {
 	title: string
-	view: InsightsChartView
-	setView: (view: InsightsChartView) => void
-	views?: readonly InsightsChartView[]
+	view: View
+	setView: (view: View) => void
+	views: readonly View[]
 }
 
 const VIEW_OPTIONS: Readonly<Record<InsightsChartView, { icon: string, label: string, title: string }>> = {
@@ -46,7 +48,9 @@ const VIEW_OPTIONS: Readonly<Record<InsightsChartView, { icon: string, label: st
 	}
 }
 
-export const InsightsChartViewToggle: React.FC<InsightsChartViewToggleProps> = ({ title, view, setView, views = ['pie', 'bar'] }) =>
+export const InsightsChartViewToggle = <View extends InsightsChartView,>(
+	{ title, view, setView, views }: InsightsChartViewToggleProps<View>
+) =>
 	<div
 		className="insights-chart-view-toggle"
 		role="group"

--- a/src/js/components/InsightsMenu/InsightsChartViewToggle.tsx
+++ b/src/js/components/InsightsMenu/InsightsChartViewToggle.tsx
@@ -4,11 +4,12 @@ import React from 'react'
 import type { InsightsChartView } from '../../types/Insights'
 
 interface ViewToggleButtonProps extends InsightsChartViewToggleProps {
+	icon: string
 	label: string
 	currentView: InsightsChartView
 }
 
-const ViewToggleButton: React.FC<ViewToggleButtonProps> = ({ title, label, view, setView, currentView }) =>
+const ViewToggleButton: React.FC<ViewToggleButtonProps> = ({ icon, title, label, view, setView, currentView }) =>
 	<button
 		type="button"
 		className={classnames('insights-chart-view-toggle-option', { 'active-view': currentView === view })}
@@ -16,7 +17,7 @@ const ViewToggleButton: React.FC<ViewToggleButtonProps> = ({ title, label, view,
 		title={title}
 		onClick={() => setView(view)}
 	>
-		<span className={`dashicons dashicons-chart-${view}`} aria-hidden="true" />
+		<span className={`dashicons dashicons-${icon}`} aria-hidden="true" />
 		<span className="screen-reader-text">{label}</span>
 	</button>
 
@@ -24,27 +25,38 @@ export interface InsightsChartViewToggleProps {
 	title: string
 	view: InsightsChartView
 	setView: (view: InsightsChartView) => void
+	views?: readonly InsightsChartView[]
 }
 
-export const InsightsChartViewToggle: React.FC<InsightsChartViewToggleProps> = ({ title, view, setView }) =>
+const VIEW_OPTIONS: Readonly<Record<InsightsChartView, { icon: string, label: string, title: string }>> = {
+	pie: {
+		icon: 'chart-pie',
+		label: __('Chart view', 'code-snippets'),
+		title: __('Switch to chart view', 'code-snippets')
+	},
+	bar: {
+		icon: 'chart-bar',
+		label: __('List view', 'code-snippets'),
+		title: __('Switch to list view', 'code-snippets')
+	},
+	cloud: {
+		icon: 'cloud',
+		label: __('Tags cloud view', 'code-snippets'),
+		title: __('Switch to tags cloud view', 'code-snippets')
+	}
+}
+
+export const InsightsChartViewToggle: React.FC<InsightsChartViewToggleProps> = ({ title, view, setView, views = ['pie', 'bar'] }) =>
 	<div
 		className="insights-chart-view-toggle"
 		role="group"
 		aria-label={sprintf(__('%s chart view', 'code-snippets'), title)}
 	>
-		<ViewToggleButton
-			view="pie"
-			label={__('Pie chart view', 'code-snippets')}
-			title={__('Switch to pie chart view', 'code-snippets')}
+		{views.map(option => <ViewToggleButton
+			key={option}
+			view={option}
+			{...VIEW_OPTIONS[option]}
 			setView={setView}
 			currentView={view}
-		/>
-
-		<ViewToggleButton
-			view="bar"
-			label={__('Bar chart view', 'code-snippets')}
-			title={__('Switch to bar chart view', 'code-snippets')}
-			setView={setView}
-			currentView={view}
-		/>
+		/>)}
 	</div>

--- a/src/js/components/InsightsMenu/InsightsCharts.tsx
+++ b/src/js/components/InsightsMenu/InsightsCharts.tsx
@@ -1,3 +1,4 @@
+import { _n, sprintf } from '@wordpress/i18n'
 import classnames from 'classnames'
 import React, { useMemo } from 'react'
 import { InsightsChartViewToggle } from './InsightsChartViewToggle'
@@ -6,6 +7,10 @@ import type { InsightsChartEntry, InsightsChartKey, InsightsChartView } from '..
 const PERCENTAGE_MAX = 100
 
 const DEFAULT_COLOR = '#646970'
+
+const TAG_CLOUD_MIN_FONT_SIZE = 0.875
+
+const TAG_CLOUD_FONT_SIZE_RANGE = 0.625
 
 const getPieBackground = (
 	entries: Readonly<Record<string, InsightsChartEntry>>,
@@ -87,6 +92,28 @@ const PieChart: React.FC<ChartProps> = ({ colors, entries }) => {
 	)
 }
 
+const TagCloud: React.FC<ChartProps> = ({ entries }) => {
+	const largestCount = useMemo(() =>
+		Math.max(1, ...Object.values(entries).map(entry => Number(entry.count))),
+	[entries])
+
+	return (
+		<ul className="insights-tags-cloud">
+			{Object.entries(entries).map(([key, entry]) =>
+				<li
+					key={key}
+					style={{ fontSize: `${TAG_CLOUD_MIN_FONT_SIZE + Number(entry.count) / largestCount * TAG_CLOUD_FONT_SIZE_RANGE}rem` }}
+				>
+					<EntryLabel {...entry} />
+					<span className="screen-reader-text">{sprintf(
+						_n(' (%s snippet)', ' (%s snippets)', Number(entry.count), 'code-snippets'),
+						entry.count
+					)}</span>
+				</li>)}
+		</ul>
+	)
+}
+
 export interface InsightsChartProps {
 	chart: InsightsChartKey
 	entries: Readonly<Record<string, InsightsChartEntry>>
@@ -94,6 +121,7 @@ export interface InsightsChartProps {
 	view: InsightsChartView
 	setView?: (view: InsightsChartView) => void
 	colors?: Readonly<Record<string, string>>
+	views?: readonly InsightsChartView[]
 }
 
 export const InsightsChart: React.FC<InsightsChartProps> = ({
@@ -102,7 +130,8 @@ export const InsightsChart: React.FC<InsightsChartProps> = ({
 	entries,
 	setView,
 	title,
-	view
+	view,
+	views
 }) =>
 	<section
 		className="insights-chart-card"
@@ -112,11 +141,13 @@ export const InsightsChart: React.FC<InsightsChartProps> = ({
 	>
 		<div className="insights-chart-card-header">
 			<h2 id={`insights-chart-${chart}-heading`}>{title}</h2>
-			{setView && <InsightsChartViewToggle title={title} view={view} setView={setView} />}
+			{setView && <InsightsChartViewToggle title={title} view={view} setView={setView} views={views} />}
 		</div>
 		{'bar' === view
 			? <BarChart colors={colors} entries={entries} />
-			: <PieChart colors={colors} entries={entries} />}
+			: 'pie' === view
+				? <PieChart colors={colors} entries={entries} />
+				: <TagCloud entries={entries} />}
 	</section>
 
 export interface TotalsInsightsChartProps extends InsightsChartEntry {

--- a/src/js/components/InsightsMenu/InsightsCharts.tsx
+++ b/src/js/components/InsightsMenu/InsightsCharts.tsx
@@ -2,7 +2,7 @@ import { _n, sprintf } from '@wordpress/i18n'
 import classnames from 'classnames'
 import React, { useMemo } from 'react'
 import { InsightsChartViewToggle } from './InsightsChartViewToggle'
-import type { InsightsChartEntry, InsightsChartKey, InsightsChartView } from '../../types/Insights'
+import type { InsightsChartEntry, InsightsChartKey, InsightsChartViews, InsightsConfigurableChartKey } from '../../types/Insights'
 
 const PERCENTAGE_MAX = 100
 
@@ -114,17 +114,17 @@ const TagCloud: React.FC<ChartProps> = ({ entries }) => {
 	)
 }
 
-export interface InsightsChartProps {
-	chart: InsightsChartKey
+export interface InsightsChartProps<Chart extends InsightsConfigurableChartKey> {
+	chart: Chart
 	entries: Readonly<Record<string, InsightsChartEntry>>
 	title: string
-	view: InsightsChartView
-	setView?: (view: InsightsChartView) => void
+	view: InsightsChartViews[Chart]
+	setView?: (view: InsightsChartViews[Chart]) => void
 	colors?: Readonly<Record<string, string>>
-	views?: readonly InsightsChartView[]
+	views: readonly InsightsChartViews[Chart][]
 }
 
-export const InsightsChart: React.FC<InsightsChartProps> = ({
+export const InsightsChart = <Chart extends InsightsConfigurableChartKey,>({
 	chart,
 	colors,
 	entries,
@@ -132,7 +132,7 @@ export const InsightsChart: React.FC<InsightsChartProps> = ({
 	title,
 	view,
 	views
-}) =>
+}: InsightsChartProps<Chart>) =>
 	<section
 		className="insights-chart-card"
 		data-insights-chart={chart}

--- a/src/js/components/InsightsMenu/InsightsDashboard.tsx
+++ b/src/js/components/InsightsMenu/InsightsDashboard.tsx
@@ -5,7 +5,7 @@ import { SNIPPET_SCOPE_DESCRIPTIONS } from '../../utils/snippets/snippets'
 import { buildUrl } from '../../utils/urls'
 import { useRestAPI } from '../../hooks/useRestAPI'
 import { InsightsChart, TotalsInsightsChart } from './InsightsCharts'
-import type { InsightChartPreferencesSchema, InsightsChartEntry, InsightsChartView, InsightsChartViews, InsightsConfigurableChartKey, InsightsSummary } from '../../types/Insights'
+import type { InsightChartPreferencesSchema, InsightsChartEntry, InsightsChartViews, InsightsConfigurableChartKey, InsightsSummary } from '../../types/Insights'
 import type { SnippetCodeScope, SnippetType } from '../../types/Snippet'
 
 export const DEFAULT_INSIGHTS_CHART_VIEWS: InsightsChartViews = window.CODE_SNIPPETS?.insightsChartViews ?? {
@@ -53,12 +53,12 @@ interface StaticChartProps {
 	summary: InsightsSummary
 }
 
-interface ConfigurableChartProps extends StaticChartProps {
-	view: InsightsChartView
-	setView: (view: InsightsChartView) => void
+interface ConfigurableChartProps<Chart extends InsightsConfigurableChartKey> extends StaticChartProps {
+	view: InsightsChartViews[Chart]
+	setView: (view: InsightsChartViews[Chart]) => void
 }
 
-const SnippetTypeChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
+const SnippetTypeChart: React.FC<ConfigurableChartProps<'type'>> = ({ summary, view, setView }) =>
 	<InsightsChart
 		chart="type"
 		title={__('Snippet type', 'code-snippets')}
@@ -67,11 +67,12 @@ const SnippetTypeChart: React.FC<ConfigurableChartProps> = ({ summary, view, set
 				[type, { ...entry, url: buildUrl(window.CODE_SNIPPETS?.urls.manage, { subpage: 'snippets', type }) }])
 		)}
 		colors={INSIGHTS_TYPE_COLORS}
+		views={['pie', 'bar']}
 		view={view}
 		setView={setView}
 	/>
 
-const ActivationStatusChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
+const ActivationStatusChart: React.FC<ConfigurableChartProps<'activation'>> = ({ summary, view, setView }) =>
 	<InsightsChart
 		chart="activation"
 		title={__('Activation status', 'code-snippets')}
@@ -88,21 +89,23 @@ const ActivationStatusChart: React.FC<ConfigurableChartProps> = ({ summary, view
 			}
 		}}
 		colors={INSIGHTS_ACTIVATION_COLORS}
+		views={['pie', 'bar']}
 		view={view}
 		setView={setView}
 	/>
 
-const ConditionUsageChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
+const ConditionUsageChart: React.FC<ConfigurableChartProps<'conditions'>> = ({ summary, view, setView }) =>
 	<InsightsChart
 		chart="conditions"
 		title={__('Condition usage', 'code-snippets')}
 		entries={summary.conditionCounts}
 		colors={INSIGHTS_CONDITION_COLORS}
+		views={['pie', 'bar']}
 		view={view}
 		setView={setView}
 	/>
 
-const LocationChart = ({ summary, view, setView }: ConfigurableChartProps) => {
+const LocationChart = ({ summary, view, setView }: ConfigurableChartProps<'location'>) => {
 	const entries: Record<string, InsightsChartEntry> = Object.fromEntries(
 		Object.entries(summary.locationCounts).map(([scope, count]) =>
 			[scope, { label: SNIPPET_SCOPE_DESCRIPTIONS[scope as SnippetCodeScope], count }])
@@ -114,13 +117,14 @@ const LocationChart = ({ summary, view, setView }: ConfigurableChartProps) => {
 			title={__('Location', 'code-snippets')}
 			entries={entries}
 			colors={INSIGHTS_LOCATION_COLORS}
+			views={['pie', 'bar']}
 			view={view}
 			setView={setView}
 		/>
 	)
 }
 
-const TagsChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
+const TagsChart: React.FC<ConfigurableChartProps<'tags'>> = ({ summary, view, setView }) =>
 	<InsightsChart
 		chart="tags"
 		title={__('Tags', 'code-snippets')}
@@ -128,66 +132,20 @@ const TagsChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView })
 			Object.entries(summary.tagCounts).map(([tag, entry]) =>
 				[tag, { ...entry, url: buildUrl(window.CODE_SNIPPETS?.urls.manage, { tag }) }])
 		)}
+		views={['bar', 'cloud']}
 		view={view}
 		setView={setView}
-		views={['bar', 'cloud']}
 	/>
 
 export interface InsightsDashboardProps {
 	summary: InsightsSummary
 }
 
-interface InsightsChartGridProps {
-	summary: InsightsSummary
-	chartViews: InsightsChartViews
-	setChartView: (chart: InsightsConfigurableChartKey, view: InsightsChartView) => void
-}
-
-const InsightsChartGrid: React.FC<InsightsChartGridProps> = ({ summary, chartViews, setChartView }) =>
-	<section className="insights-chart-grid">
-		<TotalsInsightsChart
-			chart="total"
-			label={__('Total snippets', 'code-snippets')}
-			count={Number(summary.active) + Number(summary.inactive)}
-		/>
-
-		<SnippetTypeChart
-			summary={summary}
-			view={chartViews.type}
-			setView={view => setChartView('type', view)}
-		/>
-
-		<ActivationStatusChart
-			summary={summary}
-			view={chartViews.activation}
-			setView={view => setChartView('activation', view)}
-		/>
-
-		<ConditionUsageChart
-			summary={summary}
-			view={chartViews.conditions}
-			setView={view => setChartView('conditions', view)}
-		/>
-
-		<LocationChart
-			summary={summary}
-			view={chartViews.location}
-			setView={view => setChartView('location', view)}
-		/>
-
-		<TagsChart
-			summary={summary}
-			view={chartViews.tags}
-			setView={view => setChartView('tags', view)}
-		/>
-	</section>
-
 export const InsightsDashboard: React.FC<InsightsDashboardProps> = ({ summary }) => {
 	const { api } = useRestAPI()
 	const [chartViews, setChartViews] = useState<InsightsChartViews>(DEFAULT_INSIGHTS_CHART_VIEWS)
-
-	const updateChartView = (chart: InsightsConfigurableChartKey, view: InsightsChartView) => {
-		const views = { ...chartViews, [chart]: view }
+	const updateChartView = <Chart extends InsightsConfigurableChartKey,>(chart: Chart, view: InsightsChartViews[Chart]) => {
+		const views: InsightsChartViews = { ...chartViews, [chart]: view }
 
 		setChartViews(views)
 
@@ -205,6 +163,38 @@ export const InsightsDashboard: React.FC<InsightsDashboardProps> = ({ summary })
 
 		<hr className="wp-header-end"></hr>
 
-		<InsightsChartGrid summary={summary} chartViews={chartViews} setChartView={updateChartView} />
+		<section className="insights-chart-grid">
+			<TotalsInsightsChart chart="total" label={__('Total snippets', 'code-snippets')} count={Number(summary.active) + Number(summary.inactive)} />
+
+			<SnippetTypeChart
+				summary={summary}
+				view={chartViews.type}
+				setView={view => updateChartView('type', view)}
+			/>
+
+			<ActivationStatusChart
+				summary={summary}
+				view={chartViews.activation}
+				setView={view => updateChartView('activation', view)}
+			/>
+
+			<ConditionUsageChart
+				summary={summary}
+				view={chartViews.conditions}
+				setView={view => updateChartView('conditions', view)}
+			/>
+
+			<LocationChart
+				summary={summary}
+				view={chartViews.location}
+				setView={view => updateChartView('location', view)}
+			/>
+
+			<TagsChart
+				summary={summary}
+				view={chartViews.tags}
+				setView={view => updateChartView('tags', view)}
+			/>
+		</section>
 	</>
 }

--- a/src/js/components/InsightsMenu/InsightsDashboard.tsx
+++ b/src/js/components/InsightsMenu/InsightsDashboard.tsx
@@ -12,7 +12,8 @@ export const DEFAULT_INSIGHTS_CHART_VIEWS: InsightsChartViews = window.CODE_SNIP
 	type: 'bar',
 	activation: 'pie',
 	conditions: 'pie',
-	location: 'bar'
+	location: 'bar',
+	tags: 'bar'
 }
 
 export const INSIGHTS_TYPE_COLORS: Readonly<Record<SnippetType, string>> = {
@@ -119,7 +120,7 @@ const LocationChart = ({ summary, view, setView }: ConfigurableChartProps) => {
 	)
 }
 
-const TagsChart: React.FC<StaticChartProps> = ({ summary }) =>
+const TagsChart: React.FC<ConfigurableChartProps> = ({ summary, view, setView }) =>
 	<InsightsChart
 		chart="tags"
 		title={__('Tags', 'code-snippets')}
@@ -127,12 +128,59 @@ const TagsChart: React.FC<StaticChartProps> = ({ summary }) =>
 			Object.entries(summary.tagCounts).map(([tag, entry]) =>
 				[tag, { ...entry, url: buildUrl(window.CODE_SNIPPETS?.urls.manage, { tag }) }])
 		)}
-		view="bar"
+		view={view}
+		setView={setView}
+		views={['bar', 'cloud']}
 	/>
 
 export interface InsightsDashboardProps {
 	summary: InsightsSummary
 }
+
+interface InsightsChartGridProps {
+	summary: InsightsSummary
+	chartViews: InsightsChartViews
+	setChartView: (chart: InsightsConfigurableChartKey, view: InsightsChartView) => void
+}
+
+const InsightsChartGrid: React.FC<InsightsChartGridProps> = ({ summary, chartViews, setChartView }) =>
+	<section className="insights-chart-grid">
+		<TotalsInsightsChart
+			chart="total"
+			label={__('Total snippets', 'code-snippets')}
+			count={Number(summary.active) + Number(summary.inactive)}
+		/>
+
+		<SnippetTypeChart
+			summary={summary}
+			view={chartViews.type}
+			setView={view => setChartView('type', view)}
+		/>
+
+		<ActivationStatusChart
+			summary={summary}
+			view={chartViews.activation}
+			setView={view => setChartView('activation', view)}
+		/>
+
+		<ConditionUsageChart
+			summary={summary}
+			view={chartViews.conditions}
+			setView={view => setChartView('conditions', view)}
+		/>
+
+		<LocationChart
+			summary={summary}
+			view={chartViews.location}
+			setView={view => setChartView('location', view)}
+		/>
+
+		<TagsChart
+			summary={summary}
+			view={chartViews.tags}
+			setView={view => setChartView('tags', view)}
+		/>
+	</section>
 
 export const InsightsDashboard: React.FC<InsightsDashboardProps> = ({ summary }) => {
 	const { api } = useRestAPI()
@@ -157,38 +205,6 @@ export const InsightsDashboard: React.FC<InsightsDashboardProps> = ({ summary })
 
 		<hr className="wp-header-end"></hr>
 
-		<section className="insights-chart-grid">
-			<TotalsInsightsChart
-				chart="total"
-				label={__('Total snippets', 'code-snippets')}
-				count={Number(summary.active) + Number(summary.inactive)}
-			/>
-
-			<SnippetTypeChart
-				summary={summary}
-				view={chartViews.type}
-				setView={view => updateChartView('type', view)}
-			/>
-
-			<ActivationStatusChart
-				summary={summary}
-				view={chartViews.activation}
-				setView={view => updateChartView('activation', view)}
-			/>
-
-			<ConditionUsageChart
-				summary={summary}
-				view={chartViews.conditions}
-				setView={view => updateChartView('conditions', view)}
-			/>
-
-			<LocationChart
-				summary={summary}
-				view={chartViews.location}
-				setView={view => updateChartView('location', view)}
-			/>
-
-			<TagsChart summary={summary} />
-		</section>
+		<InsightsChartGrid summary={summary} chartViews={chartViews} setChartView={updateChartView} />
 	</>
 }

--- a/src/js/types/Insights.ts
+++ b/src/js/types/Insights.ts
@@ -2,9 +2,9 @@ import type { SnippetScope, SnippetType } from './Snippet'
 
 export type InsightsChartKey = 'total' | InsightsConfigurableChartKey | 'tags'
 
-export type InsightsConfigurableChartKey = 'type' | 'activation' | 'conditions' | 'location'
+export type InsightsConfigurableChartKey = 'type' | 'activation' | 'conditions' | 'location' | 'tags'
 
-export type InsightsChartView = 'pie' | 'bar'
+export type InsightsChartView = 'pie' | 'bar' | 'cloud'
 
 export type InsightsChartViews = Readonly<Record<InsightsConfigurableChartKey, InsightsChartView>>
 

--- a/src/js/types/Insights.ts
+++ b/src/js/types/Insights.ts
@@ -1,12 +1,18 @@
 import type { SnippetScope, SnippetType } from './Snippet'
 
-export type InsightsChartKey = 'total' | InsightsConfigurableChartKey | 'tags'
+export type InsightsChartKey = 'total' | InsightsConfigurableChartKey
 
 export type InsightsConfigurableChartKey = 'type' | 'activation' | 'conditions' | 'location' | 'tags'
 
 export type InsightsChartView = 'pie' | 'bar' | 'cloud'
 
-export type InsightsChartViews = Readonly<Record<InsightsConfigurableChartKey, InsightsChartView>>
+export type InsightsChartViews = Readonly<{
+	type: 'pie' | 'bar'
+	activation: 'pie' | 'bar'
+	conditions: 'pie' | 'bar'
+	location: 'pie' | 'bar'
+	tags: 'bar' | 'cloud'
+}>
 
 export interface InsightsChartEntry {
 	readonly label: string

--- a/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
+++ b/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
@@ -99,7 +99,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 	 */
 	protected function get_update_request_schema(): array {
 		return [
-			'description'       => esc_html__( 'Pie or bar view for each Insights chart.', 'code-snippets' ),
+			'description'       => esc_html__( 'Supported chart-specific view for each Insights chart; tags also supports the cloud view.', 'code-snippets' ),
 			'type'              => 'object',
 			'required'          => true,
 			'validate_callback' => [ $this, 'validate_insights_chart_views' ],

--- a/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
+++ b/src/php/REST_API/Preferences/Insights_View_Rest_Controller.php
@@ -32,12 +32,18 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 	/**
 	 * Insights charts with independently configurable views.
 	 */
-	public const CHART_KEYS = [ 'type', 'activation', 'conditions', 'location' ];
+	public const CHART_KEYS = [ 'type', 'activation', 'conditions', 'location', 'tags' ];
 
 	/**
 	 * Valid Insights chart view values.
 	 */
-	public const CHART_VIEWS = [ 'pie', 'bar' ];
+	public const CHART_VIEWS = [
+		'type'       => [ 'pie', 'bar' ],
+		'activation' => [ 'pie', 'bar' ],
+		'conditions' => [ 'pie', 'bar' ],
+		'location'   => [ 'pie', 'bar' ],
+		'tags'       => [ 'bar', 'cloud' ],
+	];
 
 	/**
 	 * The Insights chart views shown when no preference has been saved.
@@ -47,6 +53,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 		'activation' => 'pie',
 		'conditions' => 'pie',
 		'location'   => 'bar',
+		'tags'       => 'bar',
 	];
 
 	/**
@@ -65,7 +72,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 			self::CHART_KEYS,
 			static function ( array $normalized, string $key ) use ( $views ): array {
 				$view = $views[ $key ] ?? self::DEFAULT_VIEWS[ $key ];
-				$normalized[ $key ] = in_array( $view, self::CHART_VIEWS, true )
+				$normalized[ $key ] = in_array( $view, self::CHART_VIEWS[ $key ], true )
 					? $view
 					: self::DEFAULT_VIEWS[ $key ];
 
@@ -118,7 +125,7 @@ final class Insights_View_Rest_Controller extends Preference_REST_Controller {
 
 			$view = $views[ $key ];
 
-			if ( ! in_array( $view, self::CHART_VIEWS, true ) ) {
+			if ( ! in_array( $view, self::CHART_VIEWS[ $key ], true ) ) {
 				return false;
 			}
 		}

--- a/tests/e2e/code-snippets-insights.spec.ts
+++ b/tests/e2e/code-snippets-insights.spec.ts
@@ -116,16 +116,11 @@ test.describe('Insights screen', () => {
 		await expect(withoutConditions.locator('strong')).toHaveText('4')
 	})
 
-	test('shows used tags in a fixed bar chart', async ({ page }) => {
+	test('switches used tags between bar and cloud views', async ({ page }) => {
 		await SnippetsTestHelper.createSnippetViaCli({
-			name: 'Insights Shared and Alpha Tags',
+			name: 'Insights Shared Tag',
 			active: true,
-			tags: ['Shared', 'Alpha', 'Shared']
-		})
-		await SnippetsTestHelper.createSnippetViaCli({
-			name: 'Insights Shared and Beta Tags',
-			active: true,
-			tags: ['Shared', 'Beta']
+			tags: ['Shared']
 		})
 
 		await page.goto(URLS.SNIPPETS_ADMIN.replace('page=snippets', 'page=code-snippets-insights'))
@@ -134,11 +129,20 @@ test.describe('Insights screen', () => {
 		await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible()
 		await expect(tagsChart).toHaveAttribute('data-view', 'bar')
 		await expect(tagsChart.locator('.insights-bar-chart')).toContainText('Shared')
-		await expect(tagsChart.locator('.insights-bar-chart')).toContainText('2')
-		await expect(tagsChart.locator('.insights-bar-chart')).toContainText('Alpha')
-		await expect(tagsChart.locator('.insights-bar-chart')).toContainText('Beta')
-		await expect(tagsChart.locator('.insights-chart-view-toggle')).toHaveCount(0)
-		await expect(tagsChart.locator('.insights-pie-chart')).toHaveCount(0)
+		await expect(tagsChart.getByRole('button', { name: 'Tags cloud view' })).toBeVisible()
+
+		const response = page.waitForResponse(request =>
+			'POST' === request.request().method() && request.url().includes('/preferences/insights-chart-views')
+		)
+		await tagsChart.getByRole('button', { name: 'Tags cloud view' }).click()
+		await response
+
+		await expect(tagsChart).toHaveAttribute('data-view', 'cloud')
+		await expect(tagsChart.locator('.insights-tags-cloud')).toContainText('Shared')
+		await expect(tagsChart.locator('.insights-bar-chart')).toHaveCount(0)
+
+		await page.reload()
+		await expect(tagsChart).toHaveAttribute('data-view', 'cloud')
 	})
 
 	test('links chart entries to their filtered snippet lists', async ({ page, baseURL }) => {

--- a/tests/e2e/code-snippets-insights.spec.ts
+++ b/tests/e2e/code-snippets-insights.spec.ts
@@ -118,6 +118,11 @@ test.describe('Insights screen', () => {
 
 	test('switches used tags between bar and cloud views', async ({ page }) => {
 		await SnippetsTestHelper.createSnippetViaCli({
+			name: 'Insights Shared and Alpha Tags',
+			active: true,
+			tags: ['Shared', 'Alpha']
+		})
+		await SnippetsTestHelper.createSnippetViaCli({
 			name: 'Insights Shared Tag',
 			active: true,
 			tags: ['Shared']
@@ -138,7 +143,14 @@ test.describe('Insights screen', () => {
 		await response
 
 		await expect(tagsChart).toHaveAttribute('data-view', 'cloud')
-		await expect(tagsChart.locator('.insights-tags-cloud')).toContainText('Shared')
+		const tagCloud = tagsChart.locator('.insights-tags-cloud')
+		const sharedTag = tagCloud.locator('li').filter({ hasText: /^Shared/ })
+		const alphaTag = tagCloud.locator('li').filter({ hasText: /^Alpha/ })
+
+		await expect(sharedTag).toHaveAccessibleName('Shared (2 snippets)')
+		await expect(alphaTag).toHaveAccessibleName('Alpha (1 snippet)')
+		expect(await sharedTag.evaluate(element => Number.parseFloat(getComputedStyle(element).fontSize)))
+			.toBeGreaterThan(await alphaTag.evaluate(element => Number.parseFloat(getComputedStyle(element).fontSize)))
 		await expect(tagsChart.locator('.insights-bar-chart')).toHaveCount(0)
 
 		await page.reload()
@@ -251,7 +263,7 @@ test.describe('Insights screen', () => {
 			await route.fulfill({ status: 500, body: JSON.stringify({ message: 'Save failed' }) })
 		})
 
-		await conditionsChart.getByRole('button', { name: 'Bar chart view' }).click()
+		await conditionsChart.getByRole('button', { name: 'List view' }).click()
 
 		await expect(conditionsChart).toHaveAttribute('data-view', 'pie')
 	})
@@ -281,13 +293,13 @@ test.describe('Insights screen', () => {
 			await route.fulfill({ status: 200, body: JSON.stringify({ views }) })
 		})
 
-		await typeChart.getByRole('button', { name: 'Pie chart view' }).click()
+		await typeChart.getByRole('button', { name: 'Chart view' }).click()
 		await firstRequestStarted
 
 		const successfulResponse = page.waitForResponse(response =>
 			'POST' === response.request().method() && 200 === response.status()
 		)
-		await activationChart.getByRole('button', { name: 'Bar chart view' }).click()
+		await activationChart.getByRole('button', { name: 'List view' }).click()
 		await successfulResponse
 
 		if (undefined === rejectFirstRequest) {

--- a/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
+++ b/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
@@ -119,6 +119,18 @@ class Insights_View_Rest_Controller_Test extends AdminUnitTestCase {
 		);
 
 		$this->assertSame( 400, $response->get_status() );
+
+		foreach (
+			[
+				array_merge( Insights_View_Rest_Controller::DEFAULT_VIEWS, [ 'type' => 'cloud' ] ),
+				array_merge( Insights_View_Rest_Controller::DEFAULT_VIEWS, [ 'tags' => 'pie' ] ),
+			] as $views
+		) {
+			$response = $this->dispatch( 'POST', [ 'views' => $views ] );
+
+			$this->assertSame( 400, $response->get_status() );
+		}
+
 		$this->assertFalse( get_option( Insights_View_Rest_Controller::OPTION_NAME ) );
 	}
 

--- a/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
+++ b/tests/unit/REST_API/Preferences/Insights_View_Rest_Controller_Test.php
@@ -94,6 +94,7 @@ class Insights_View_Rest_Controller_Test extends AdminUnitTestCase {
 			'activation' => 'bar',
 			'conditions' => 'bar',
 			'location'   => 'pie',
+			'tags'       => 'cloud',
 		];
 		$response = $this->dispatch( 'POST', [ 'views' => $views ] );
 
@@ -133,6 +134,7 @@ class Insights_View_Rest_Controller_Test extends AdminUnitTestCase {
 				'activation' => 'pie',
 				'conditions' => 'pie',
 				'location'   => 'bar',
+				'tags'       => 'bar',
 			],
 			Insights_View_Rest_Controller::get_insights_chart_views()
 		);


### PR DESCRIPTION
Enhance insights "tags" section. allow the user to display the data as a list or as a tag cloud.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Tags chart to Insights with bar and cloud display options.
  * Added a tag cloud view with responsive sizing, wrapping layout, and accessible count descriptions.
  * Chart view selections can now be configured and persist across page reloads.

* **Bug Fixes**
  * Improved chart card sizing and tag layout consistency.
  * Added validation for chart-specific view options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->