### PR TITLE
fix: duplicate Elementor promotion registration

### DIFF
--- a/src/php/Plugin.php
+++ b/src/php/Plugin.php
@@ -142,10 +142,6 @@ class Plugin {
 		new Upgrader( PLUGIN_VERSION, $this->db );
 		new Admin_Bar();
 
-		if ( is_admin() ) {
-			new Promotion_Manager();
-		}
-
 		$this->init_snippet_files();
 
 		add_action( 'rest_api_init', [ $this, 'init_rest_api' ], 1 );

--- a/tests/unit/Plugin_Test.php
+++ b/tests/unit/Plugin_Test.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Code_Snippets;
+
+use Code_Snippets\Integration\Promotions\Other\Elementor_Editor;
+
+/**
+ * Tests for the main plugin class.
+ */
+class Plugin_Test extends UnitTestCase {
+
+	/**
+	 * Loading the plugin in the admin registers one Elementor promotion callback.
+	 *
+	 * @return void
+	 */
+	public function test_load_plugin_registers_elementor_promotion_once(): void {
+		set_current_screen( 'dashboard' );
+
+		$callbacks_before = $this->get_elementor_promotion_callbacks();
+
+		$plugin = new Plugin();
+		$plugin->load_plugin();
+
+		$this->assertCount( count( $callbacks_before ) + 1, $this->get_elementor_promotion_callbacks() );
+	}
+
+	/**
+	 * Retrieve the callbacks that initialize Elementor promotions.
+	 *
+	 * @return array
+	 */
+	private function get_elementor_promotion_callbacks(): array {
+		global $wp_filter;
+
+		$promotion_callbacks = [];
+
+		foreach ( $wp_filter['elementor/init']->callbacks ?? [] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$function = $callback['function'];
+
+				if ( is_array( $function ) && $function[0] instanceof Elementor_Editor && 'promotion_in_custom_css_section' === $function[1] ) {
+					$promotion_callbacks[] = $function;
+				}
+			}
+		}
+
+		return $promotion_callbacks;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/codesnippetspro/code-snippets/issues/550

And adds tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin initialization to prevent duplicate promotion manager setup while preserving promotion features in the admin dashboard.

- **Tests**
  - Added coverage verifying that the Elementor promotion callback is registered exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->